### PR TITLE
Use SSL to talk to pypi

### DIFF
--- a/package-python
+++ b/package-python
@@ -49,7 +49,7 @@ FULL_NAME="James McGuinness"
 EMAIL="jrm@yelp.com"
 MAINTAINER="$FULL_NAME <$EMAIL>"
 
-PYPI_SERVER=http://pypi.yelpcorp.com/simple
+PYPI_SERVER=https://pypi.yelpcorp.com/simple
 
 FPM_ARGS=(
  -s python -t deb -m "${MAINTAINER}"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = py26
 indexserver =
-    default = http://pypi.yelpcorp.com/simple/
+    default = https://pypi.yelpcorp.com/simple/
 
 [testenv]
 deps=


### PR DESCRIPTION
Should not change any behaviour (sort of getting rid of warnings).