### PR TITLE
Fix yaml_cache data object being modified after file read

### DIFF
--- a/service_configuration_lib/__init__.py
+++ b/service_configuration_lib/__init__.py
@@ -88,7 +88,7 @@ def _read_yaml_file(file_name):
             data = load_yaml(fd.read())
             data = data or {}
             if _use_yaml_cache:
-                _yaml_cache[file_name] = data
+                _yaml_cache[file_name] = copy.deepcopy(data)
     except IOError:
         pass
     except:


### PR DESCRIPTION
If I understand correctly, the reason for caching is to avoid reading the same yaml file again and again from disk. Since the yaml file is per service, I am seeing duplicated constrains when more than one instances of the same service are worked in a batch. 

'constraints': [['hostname', 'UNIQUE'], **['superregion', 'GROUP_BY', '1'], ['region', 'UNLIKE', 'dc6-prod'], ['pool', 'LIKE', 'lucy'], ['superregion', 'GROUP_BY', '1'], ['region', 'UNLIKE', 'dc6-prod'], ['pool', 'LIKE', 'lucy']**]

Below pdb rootcauses the problem where 'extra_constraints' in the cached object gets modified by the service_configuration_lib client:

(Pdb) p service_configuration_lib._yaml_cache
{'/nail/home/hliu/robj-test-service/deploy.yaml': {'pipeline': [{'instancename': 'itest'}, {'instancename': 'security-check'}, {'instancename': 'push-to-registry'}, {'instancename': 'performance-check'}, {'trigger_next_step_manually': True, 'instancename': 'mesosstage.everything'}]}, '/nail/home/hliu/robj-test-service/service.yaml': {'description': 'robj-test for docker dublin', 'external_link': 'email-robj'}, '/nail/home/hliu/robj-test-service/monitoring.yaml': {'service_type': 'marathon', 'team': 'noop'}, '/nail/home/hliu/robj-test-service/smartstack.yaml': {'main': {'proxy_port': 20509, 'advertise': ['superregion'], 'extra_advertise': {'ecosystem:testopia': ['ecosystem:testopia']}, 'discover': 'superregion'}}, u'/nail/home/hliu/robj-test-service/marathon-mesosstage.yaml': {'main': {'deploy_group': 'mesosstage.everything', 'healthcheck_cmd': 'echo hi', 'instances': 2, 'mem': 200, 'healthcheck_mode': 'cmd', 'cpus': 0.1}, 'autoscale_to_heck': {'deploy_group': 'mesosstage.everything', 'min_instances': 0, 'autoscaling': {'decision_policy': 'bespoke'}, 'mem': 5000, 'cpus': 0.1, 'max_instances': 42, 'bounce_method': 'brutal'}, 'memo-test': {'deploy_group': 'mesosstage.everything', 'deploy_blacklist': [['region', 'dc6-prod']], 'instances': 2, 'mem': 50.5, **'extra_constraints': [['hostname', 'UNIQUE'], ['region', 'GROUP_BY', '1']]**, 'cpus': 0.1, 'pool': 'lucy'}}}
(Pdb) n
-> /nail/home/hliu/paasta/paasta_tools/marathon_tools.py(325)get_calculated_constraints()
-> constraints.extend(self.get_pool_constraints())
(Pdb) p service_configuration_lib._yaml_cache
{'/nail/home/hliu/robj-test-service/deploy.yaml': {'pipeline': [{'instancename': 'itest'}, {'instancename': 'security-check'}, {'instancename': 'push-to-registry'}, {'instancename': 'performance-check'}, {'trigger_next_step_manually': True, 'instancename': 'mesosstage.everything'}]}, '/nail/home/hliu/robj-test-service/service.yaml': {'description': 'robj-test for docker dublin', 'external_link': 'email-robj'}, '/nail/home/hliu/robj-test-service/monitoring.yaml': {'service_type': 'marathon', 'team': 'noop'}, '/nail/home/hliu/robj-test-service/smartstack.yaml': {'main': {'proxy_port': 20509, 'advertise': ['superregion'], 'extra_advertise': {'ecosystem:testopia': ['ecosystem:testopia']}, 'discover': 'superregion'}}, u'/nail/home/hliu/robj-test-service/marathon-mesosstage.yaml': {'main': {'deploy_group': 'mesosstage.everything', 'healthcheck_cmd': 'echo hi', 'instances': 2, 'mem': 200, 'healthcheck_mode': 'cmd', 'cpus': 0.1}, 'autoscale_to_heck': {'deploy_group': 'mesosstage.everything', 'min_instances': 0, 'autoscaling': {'decision_policy': 'bespoke'}, 'mem': 5000, 'cpus': 0.1, 'max_instances': 42, 'bounce_method': 'brutal'}, 'memo-test': {'deploy_group': 'mesosstage.everything', 'deploy_blacklist': [['region', 'dc6-prod']], 'instances': 2, 'mem': 50.5, **'extra_constraints': [['hostname', 'UNIQUE'], ['region', 'GROUP_BY', '1'], ['region', 'UNLIKE', 'dc6-prod']],** 'cpus': 0.1, 'pool': 'lucy'}}}
(Pdb) n
-> /nail/home/hliu/paasta/paasta_tools/marathon_tools.py(326)get_calculated_constraints()
-> return [[str(val) for val in constraint] for constraint in constraints]
(Pdb) p service_configuration_lib._yaml_cache
{'/nail/home/hliu/robj-test-service/deploy.yaml': {'pipeline': [{'instancename': 'itest'}, {'instancename': 'security-check'}, {'instancename': 'push-to-registry'}, {'instancename': 'performance-check'}, {'trigger_next_step_manually': True, 'instancename': 'mesosstage.everything'}]}, '/nail/home/hliu/robj-test-service/service.yaml': {'description': 'robj-test for docker dublin', 'external_link': 'email-robj'}, '/nail/home/hliu/robj-test-service/monitoring.yaml': {'service_type': 'marathon', 'team': 'noop'}, '/nail/home/hliu/robj-test-service/smartstack.yaml': {'main': {'proxy_port': 20509, 'advertise': ['superregion'], 'extra_advertise': {'ecosystem:testopia': ['ecosystem:testopia']}, 'discover': 'superregion'}}, u'/nail/home/hliu/robj-test-service/marathon-mesosstage.yaml': {'main': {'deploy_group': 'mesosstage.everything', 'healthcheck_cmd': 'echo hi', 'instances': 2, 'mem': 200, 'healthcheck_mode': 'cmd', 'cpus': 0.1}, 'autoscale_to_heck': {'deploy_group': 'mesosstage.everything', 'min_instances': 0, 'autoscaling': {'decision_policy': 'bespoke'}, 'mem': 5000, 'cpus': 0.1, 'max_instances': 42, 'bounce_method': 'brutal'}, 'memo-test': {'deploy_group': 'mesosstage.everything', 'deploy_blacklist': [['region', 'dc6-prod']], 'instances': 2, 'mem': 50.5, **'extra_constraints': [['hostname', 'UNIQUE'], ['region', 'GROUP_BY', '1'], ['region', 'UNLIKE', 'dc6-prod'], ['pool', 'LIKE', 'lucy']]**, 'cpus': 0.1, 'pool': 'lucy'}}}
 