### PR TITLE
Add a way to list service names without reading all configuration files

### DIFF
--- a/service_configuration_lib/__init__.py
+++ b/service_configuration_lib/__init__.py
@@ -159,6 +159,10 @@ def read_services_configuration(soa_dir=DEFAULT_SOA_DIR):
         all_services.update( { service_name: service_info } )
     return all_services
 
+def list_services(soa_dir=DEFAULT_SOA_DIR):
+    rootdir = os.path.abspath(soa_dir)
+    return os.listdir(rootdir)
+
 def get_service_from_port(port, all_services=None):
     """Gets the name of the service from the port
     all_services allows you to feed in the services to look through, pass

--- a/tests/test_service_configuration_lib.py
+++ b/tests/test_service_configuration_lib.py
@@ -237,6 +237,15 @@ class ServiceConfigurationLibTestCase(T.TestCase):
             [mock.call('nodir', '1'), mock.call('nodir', '2'), mock.call('nodir', '3')])
         T.assert_equal(expected, actual)
 
+    @mock.patch('os.path.abspath', return_value='nodir')
+    @mock.patch('os.listdir', return_value=["1","2","3"])
+    def test_list_services(self, listdir_patch, abs_patch):
+        expected = ['1', '2', '3']
+        actual = service_configuration_lib.list_services(soa_dir='testdir')
+        abs_patch.assert_called_once_with('testdir')
+        listdir_patch.assert_called_once_with('nodir')
+        T.assert_equal(expected, actual)
+
     @mock.patch('service_configuration_lib.read_service_configuration_from_dir', return_value='bye')
     @mock.patch('os.path.abspath', return_value='cafe')
     def test_read_service_configuration(self, abs_patch, read_patch):


### PR DESCRIPTION
To avoid reading and parsing all configuration files if we only need a list of service names.
https://github.com/Yelp/paasta/blob/master/paasta_tools/cli/utils.py#L348