### PR TITLE
bump version to v0.12.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='service-configuration-lib',
-    version='0.12.0',
+    version='0.12.1',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',


### PR DESCRIPTION
v0.12.0 is a version from 2017-05-16 and updates are not getting through because the version keeps being the same