### PR TITLE
fix reconfiguration bug when a folder is deleted

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from service_configuration_lib.yaml_cached_view import YamlConfigsCachedView
 
 @pytest.fixture
 def mock_configs_file_watcher():
-    return MagicMock(spec=ConfigsFileWatcher)
+    return MagicMock(spec=ConfigsFileWatcher, _configs_folder='/foo', _needs_reconfigure=False)
 
 
 @pytest.fixture


### PR DESCRIPTION
Calling `setup` on a DELETE_SELF event causes the entire notifier to be recreated, but because we watch recursively, if a folder is deleted, a DELETE_SELF event occurs for the subfolder, which causes the notifier to be recreated.  Unfortunately, the old notifier was still (trying to) process events, and it would crash.

This change does two things: it delays the call to `setup()` until after the notifier has processed all events, and it makes sure that we only recreate the notifier in the event that the _root_ folder was deleted.  As far as I'm aware, there's no reason to recreate the notifier if a subfolder was deleted.