### PR TITLE
Allow overriding DEFAULT_SOA_DIR in test environment

### DIFF
--- a/service_configuration_lib/__init__.py
+++ b/service_configuration_lib/__init__.py
@@ -28,7 +28,7 @@ try:
 except ImportError:  # pragma: no cover (no libyaml-dev / pypy)
     Loader = yaml.SafeLoader
 
-DEFAULT_SOA_DIR = '/nail/etc/services'
+DEFAULT_SOA_DIR = os.getenv('DEFAULT_SOA_DIR', '/nail/etc/services')
 log = logging.getLogger(__name__)
 _yaml_cache = {}
 _use_yaml_cache = True


### PR DESCRIPTION
Many paasta libs import this constant from service_configuration_lib. Overriding this allows me to set an environment variable to change soa_config dir. I checked that no DEFAULT_SOA_DIR environment variable is set in puppet.  Make test passed. 