### PR TITLE
Add initial spark_config function for generating the SPARK_OPTS environment variable

### DIFF
--- a/.activate.sh
+++ b/.activate.sh
@@ -1,0 +1,1 @@
+venv/bin/activate

--- a/.deactivate.sh
+++ b/.deactivate.sh
@@ -1,0 +1,1 @@
+deactivate

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 virtualenv_run
 venv
 .bash_history
+.mypy_cache

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+python_version = 3.6
+check_untyped_defs = False
+warn_incomplete_stub = True
+follow_imports = silent
+ignore_missing_imports = True
+mypy_path = stubs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,7 @@
-coverage
+# Coverage==5.0 fails with `Safety level may not be changed inside a transaction`
+# on python 3.6.0 (xenial) (https://github.com/nedbat/coveragepy/issues/703)
+coverage<5
 mock
+mypy
 pre-commit>=1.0.0
 pytest

--- a/service_configuration_lib/__init__.py
+++ b/service_configuration_lib/__init__.py
@@ -20,17 +20,18 @@ import logging
 import os
 import socket
 import sys
+from typing import Mapping
 
 import yaml
 
 try:
     from yaml.cyaml import CSafeLoader as Loader
 except ImportError:  # pragma: no cover (no libyaml-dev / pypy)
-    Loader = yaml.SafeLoader
+    Loader = yaml.SafeLoader  # type: ignore
 
 DEFAULT_SOA_DIR = '/nail/etc/services'
 log = logging.getLogger(__name__)
-_yaml_cache = {}
+_yaml_cache: Mapping[str, Mapping] = {}
 _use_yaml_cache = True
 
 

--- a/service_configuration_lib/cached_view.py
+++ b/service_configuration_lib/cached_view.py
@@ -97,9 +97,9 @@ class ConfigsFileWatcher:
         Args:
         :param limit: Optional, rough limit of events to process per call
         """
+        assert self._notifier
         before_processed_count = self._processed_events_count
         currently_processed = 0
-        assert self._notifier
         while currently_processed < limit and self._notifier.check_events(timeout=0):
             self._notifier.read_events()
             self._notifier.process_events()

--- a/service_configuration_lib/cached_view.py
+++ b/service_configuration_lib/cached_view.py
@@ -99,6 +99,7 @@ class ConfigsFileWatcher:
         """
         before_processed_count = self._processed_events_count
         currently_processed = 0
+        assert self._notifier
         while currently_processed < limit and self._notifier.check_events(timeout=0):
             self._notifier.read_events()
             self._notifier.process_events()

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1,0 +1,116 @@
+import logging
+from typing import Any
+from typing import List
+from typing import Mapping
+from typing import MutableMapping
+from typing import Optional
+
+DEFAULT_SPARK_MESOS_SECRET_FILE = '/nail/etc/paasta_spark_secret'
+NON_CONFIGURABLE_SPARK_OPTS = {
+    'spark.master',
+    'spark.ui.port',
+    'spark.mesos.principal',
+    'spark.mesos.secret',
+    'spark.mesos.executor.docker.image',
+    'spark.mesos.executor.docker.parameters',
+    'spark.executorEnv.PAASTA_SERVICE',
+    'spark.executorEnv.PAASTA_INSTANCE',
+    'spark.executorEnv.PAASTA_CLUSTER',
+    'spark.executorEnv.SPARK_EXECUTOR_DIRS',
+    'spark.hadoop.fs.s3a.access.key',
+    'spark.hadoop.fs.s3a.secret.key',
+}
+log = logging.Logger(__name__)
+
+
+def get_mesos_spark_env(
+    spark_app_name: str,
+    spark_ui_port: str,
+    mesos_leader: str,
+    mesos_secret: str,
+    paasta_cluster: str,
+    paasta_pool: str,
+    paasta_service: str,
+    paasta_instance: str,
+    docker_img: str,
+    volumes: List[str],
+    user_spark_opts: Mapping[str, Any],
+    event_log_dir: Optional[str] = None,
+    needs_docker_cfg: bool = False,
+) -> Mapping[str, str]:
+    user_non_config_opts = set(user_spark_opts) & NON_CONFIGURABLE_SPARK_OPTS
+    if user_non_config_opts:
+        raise ValueError(f'The following Spark options are not user-configurable: {user_non_config_opts}')
+
+    spark_env: MutableMapping[str, str] = {
+        'spark.master': f'mesos://{mesos_leader}',
+        'spark.ui.port': spark_ui_port,
+        'spark.executorEnv.PAASTA_SERVICE': paasta_service,
+        'spark.executorEnv.PAASTA_INSTANCE': paasta_instance,
+        'spark.executorEnv.PAASTA_CLUSTER': paasta_cluster,
+        'spark.executorEnv.PAASTA_INSTANCE_TYPE': 'spark',
+        'spark.executorEnv.SPARK_EXECUTOR_DIRS': '/tmp',
+        'spark.mesos.executor.docker.parameters':
+            f'label=paasta_service={paasta_service},label=paasta_instance={paasta_instance}',
+        'spark.mesos.executor.docker.volumes': ','.join(volumes),
+        'spark.mesos.executor.docker.image': docker_img,
+        'spark.mesos.principal': 'spark',
+        'spark.mesos.secret': mesos_secret,
+
+        # User-configurable defaults here
+        'spark.app.name': spark_app_name,
+        'spark.cores.max': '4',
+        'spark.executor.cores': '2',
+        'spark.executor.memory': '4g',
+        # Use \; for multiple constraints, e.g. 'instance_type:m4.10xlarge\;pool:default'
+        'spark.mesos.constraints': 'pool:{paasta_pool}',
+        'spark.mesos.executor.docker.forcePullImage': 'true',
+        'spark.eventLog.enabled': 'true',
+    }
+    if needs_docker_cfg:
+        spark_env['spark.mesos.uris'] = 'file:///root/.dockercfg'
+
+    spark_env = {**spark_env, **user_spark_opts}
+
+    # spark_opts could be a mix of string and numbers.
+    if int(spark_env['spark.executor.cores']) > int(spark_env['spark.cores.max']):
+        raise ValueError(
+            'spark.executor.cores={executor_cores} should be not greater than spark.cores.max={max_cores}'.format(
+                executor_cores=spark_env['spark.executor.cores'],
+                max_cores=spark_env['spark.cores.max'],
+            ),
+        )
+
+    if not spark_env.get('spark.sql.shuffle.partitions'):
+        spark_env['spark.sql.shuffle.partitions'] = str(2 * int(spark_env['spark.cores.max']))
+        log.warning(
+            'spark.sql.shuffle.partitions has been set to {num_partitions} '
+            'to be equal to twice the number of requested cores, but you should '
+            'consider setting a higher value if necessary.'
+            ' Follow y/spark for help on partition sizing'.format(
+                num_partitions=spark_env['spark.sql.shuffle.partitions'],
+            ),
+        )
+
+    if spark_env['spark.eventLog.enabled'] == 'true':
+        if not spark_env.get('spark.eventLog.dir'):
+            if not event_log_dir:
+                raise ValueError('Asked for event logging but spark.eventLog.dir missing')
+            spark_env['spark.eventLog.dir'] = event_log_dir
+        log.info(f'Spark event logs available in {event_log_dir}')
+
+    spark_env['spark.mesos.executor.docker.parameters'] = 'cpus={}'.format(spark_env['spark.executor.cores'])
+    exec_mem = spark_env['spark.executor.memory']
+    if exec_mem[-1] != 'g' or not exec_mem[:-1].isdigit():
+        raise ValueError('Executor memory {} not in format dg.'.format(spark_env['spark.executor.memory']))
+    if int(exec_mem[:-1]) > 32:
+        log.warning(
+            'You have specified a large amount of memory ({exec_mem[:-1]} > 32g); '
+            'please make sure that you actually need this much, or reduce your memory requirements',
+        )
+
+    return spark_env
+
+
+def stringify_spark_env(spark_env: Mapping[str, str]) -> str:
+    return ' '.join([f'--conf {k}={v}' for k, v in spark_env.items()])

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,15 @@ setup(
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',
-    author='Yelp Operations Team',
+    author='Yelp Compute Infrastructure Team',
     author_email='opensource+scl@yelp.com',
     packages=find_packages(exclude=['tests', 'scripts']),
-    install_requires=['PyYAML >= 3.0', 'pyinotify'],
+    install_requires=[
+        'ephemeral-port-reserve >= 1.1.0',
+        'PyYAML >= 5.1',
+        'pyinotify',
+        'requests>=2.18.4',
+    ],
     license='Copyright Yelp 2013, All Rights Reserved',
     scripts=[
         'scripts/all_nodes_that_receive',

--- a/tests/service_configuration_lib_test.py
+++ b/tests/service_configuration_lib_test.py
@@ -274,7 +274,7 @@ class TestServiceConfigurationLib:
 
     @mock.patch('os.path.join', return_value='together_forever')
     @mock.patch('os.path.abspath', return_value='real_soa_dir')
-    @mock.patch('service_configuration_lib._read_yaml_file', return_value={'what': 'info'})
+    @mock.patch('service_configuration_lib.read_yaml_file', return_value={'what': 'info'})
     def test_read_extra_service_information(self, info_patch, abs_patch, join_patch):
         expected = {'what': 'info'}
         actual = service_configuration_lib.read_extra_service_information(
@@ -288,22 +288,22 @@ class TestServiceConfigurationLib:
 
     @mock.patch('io.open', autospec=True)
     @mock.patch('service_configuration_lib.load_yaml', return_value={'data': 'mock'})
-    def test_read_yaml_file_single(self, load_patch, open_patch):
+    def testread_yaml_file_single(self, load_patch, open_patch):
         expected = {'data': 'mock'}
         filename = 'fake_fname_uno'
-        actual = service_configuration_lib._read_yaml_file(filename)
+        actual = service_configuration_lib.read_yaml_file(filename)
         open_patch.assert_called_once_with(filename, 'r', encoding='UTF-8')
         load_patch.assert_called_once_with(open_patch.return_value.__enter__().read())
         assert expected == actual
 
     @mock.patch('io.open', autospec=True)
     @mock.patch('service_configuration_lib.load_yaml', return_value={'mmmm': 'tests'})
-    def test_read_yaml_file_with_cache(self, load_patch, open_patch):
+    def testread_yaml_file_with_cache(self, load_patch, open_patch):
         expected = {'mmmm': 'tests'}
         filename = 'fake_fname_dos'
         service_configuration_lib.enable_yaml_cache()
-        actual = service_configuration_lib._read_yaml_file(filename)
-        actual_two = service_configuration_lib._read_yaml_file(filename)
+        actual = service_configuration_lib.read_yaml_file(filename)
+        actual_two = service_configuration_lib.read_yaml_file(filename)
         open_patch.assert_called_once_with(filename, 'r', encoding='UTF-8')
         load_patch.assert_called_once_with(open_patch.return_value.__enter__().read())
         assert expected == actual
@@ -315,12 +315,12 @@ class TestServiceConfigurationLib:
 
     @mock.patch('io.open', autospec=True)
     @mock.patch('service_configuration_lib.load_yaml', return_value={'water': 'slide'})
-    def test_read_yaml_file_no_cache(self, load_patch, open_patch):
+    def testread_yaml_file_no_cache(self, load_patch, open_patch):
         expected = {'water': 'slide'}
         filename = 'fake_fname_tres'
         service_configuration_lib.disable_yaml_cache()
-        actual = service_configuration_lib._read_yaml_file(filename)
-        actual_two = service_configuration_lib._read_yaml_file(filename)
+        actual = service_configuration_lib.read_yaml_file(filename)
+        actual_two = service_configuration_lib.read_yaml_file(filename)
         open_patch.assert_any_call(filename, 'r', encoding='UTF-8')
         assert open_patch.call_count == 2
         load_patch.assert_any_call(open_patch.return_value.__enter__().read())

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -1,0 +1,79 @@
+import pytest
+
+from service_configuration_lib.spark_config import get_mesos_spark_env
+
+
+@pytest.fixture
+def config_args():
+    return dict(
+        spark_app_name='my-spark-app',
+        spark_ui_port='1234',
+        mesos_leader='the-mesos-leader:5050',
+        mesos_secret='SUPER_SECRET_STRING',
+        paasta_cluster='westeros-devc',
+        paasta_pool='spark-pool',
+        paasta_service='spark-service',
+        paasta_instance='batch',
+        docker_img='docker-dev.nowhere.com/spark:latest',
+        volumes=['/nail/var:/nail/var:ro', '/etc/foo:/etc/foo:ro'],
+        user_spark_opts={},
+        event_log_dir='/var/log',
+    )
+
+
+def test_non_config_opts(config_args):
+    config_args['user_spark_opts']['spark.master'] = 'foo'
+    with pytest.raises(ValueError):
+        get_mesos_spark_env(**config_args)
+
+
+def test_invalid_cores(config_args):
+    config_args['user_spark_opts']['spark.executor.cores'] = 10
+    with pytest.raises(ValueError):
+        get_mesos_spark_env(**config_args)
+
+
+def test_invalid_mem(config_args):
+    config_args['user_spark_opts']['spark.executor.memory'] = '64x'
+    with pytest.raises(ValueError):
+        get_mesos_spark_env(**config_args)
+
+
+def test_no_event_log_dir(config_args):
+    config_args['event_log_dir'] = None
+    with pytest.raises(ValueError):
+        get_mesos_spark_env(**config_args)
+
+
+@pytest.mark.parametrize('shuffle_partitions', [None, 20])
+@pytest.mark.parametrize('needs_docker_cfg', [True, False])
+def test_get_mesos_spark_env(shuffle_partitions, needs_docker_cfg, config_args):
+    config_args['user_spark_opts']['spark.sql.shuffle.partitions'] = shuffle_partitions
+    config_args['needs_docker_cfg'] = needs_docker_cfg
+    spark_env = get_mesos_spark_env(**config_args)
+    expected = {
+        'spark.app.name': 'my-spark-app',
+        'spark.cores.max': '4',
+        'spark.eventLog.dir': '/var/log',
+        'spark.eventLog.enabled': 'true',
+        'spark.executor.cores': '2',
+        'spark.executor.memory': '4g',
+        'spark.executorEnv.PAASTA_CLUSTER': 'westeros-devc',
+        'spark.executorEnv.PAASTA_INSTANCE': 'batch',
+        'spark.executorEnv.PAASTA_INSTANCE_TYPE': 'spark',
+        'spark.executorEnv.PAASTA_SERVICE': 'spark-service',
+        'spark.executorEnv.SPARK_EXECUTOR_DIRS': '/tmp',
+        'spark.master': 'mesos://the-mesos-leader:5050',
+        'spark.mesos.constraints': 'pool:{paasta_pool}',
+        'spark.mesos.executor.docker.forcePullImage': 'true',
+        'spark.mesos.executor.docker.image': 'docker-dev.nowhere.com/spark:latest',
+        'spark.mesos.executor.docker.parameters': 'cpus=2',
+        'spark.mesos.executor.docker.volumes': '/nail/var:/nail/var:ro,/etc/foo:/etc/foo:ro',
+        'spark.mesos.principal': 'spark',
+        'spark.mesos.secret': 'SUPER_SECRET_STRING',
+        'spark.sql.shuffle.partitions': shuffle_partitions or '8',
+        'spark.ui.port': '1234',
+    }
+    if needs_docker_cfg:
+        expected['spark.mesos.uris'] = 'file:///root/.dockercfg'
+    assert spark_env == expected

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ tox_pip_extensions_ext_venv_update = true
 [testenv]
 deps = -rrequirements-dev.txt
 commands=
+    mypy service_configuration_lib
     coverage erase
     coverage run -m pytest {posargs:tests}
     coverage report --fail-under 90


### PR DESCRIPTION
This change does the following:

1. Add mypy support for this library (and fix a few related mypy issues)
2. Set up activate/deactivate functions for `aactivator`
3. Creates a `spark_config.py` file which can be imported and used to generate a dictionary containing the "right values" for the SPARK_OPTS environment variable.

Coverage fails with this issue, so I pin to <5.0: https://github.com/nedbat/coveragepy/issues/703