### PR TITLE
Set label and node-selector for kubernetes pods for spark jobs

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -134,6 +134,7 @@ def get_k8s_spark_env(
     docker_img: str,
     volumes: List[Mapping[str, str]],
     user_spark_opts: Mapping[str, Any],
+    paasta_pool: str,
     event_log_dir: Optional[str] = None,
 ) -> Mapping[str, str]:
     _check_non_configurable_spark_opts(user_spark_opts)
@@ -159,6 +160,8 @@ def get_k8s_spark_env(
         'spark.kubernetes.executor.label.paasta.yelp.com/service': paasta_service,
         'spark.kubernetes.executor.label.paasta.yelp.com/instance': paasta_instance,
         'spark.kubernetes.executor.label.paasta.yelp.com/cluster': paasta_cluster,
+        'spark.kubernetes.node.selector.yelp.com/pool': paasta_pool,
+        'spark.kubernetes.executor.label.yelp.com/pool': paasta_pool,
 
         # User-configurable defaults here
         'spark.app.name': spark_app_name,

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -30,6 +30,7 @@ def k8s_config_args():
         paasta_cluster='westeros-devc',
         paasta_service='spark-service',
         paasta_instance='batch',
+        paasta_pool='spark-pool',
         docker_img='docker-dev.nowhere.com/spark:latest',
         user_spark_opts={},
         event_log_dir='/var/log',
@@ -161,4 +162,6 @@ def test_get_k8s_spark_env(shuffle_partitions, k8s_config_args):
         'spark.kubernetes.executor.label.paasta.yelp.com/service': 'spark-service',
         'spark.kubernetes.executor.label.paasta.yelp.com/instance': 'batch',
         'spark.kubernetes.executor.label.paasta.yelp.com/cluster': 'westeros-devc',
+        'spark.kubernetes.node.selector.yelp.com/pool': 'spark-pool',
+        'spark.kubernetes.executor.label.yelp.com/pool': 'spark-pool',
     }


### PR DESCRIPTION
Kubernetes schedule uses node-selector to deduce the kubernetes pool from where the executor pods are allocated to run spark jobs. This is equivalent for spark on mesos was setting `spark.mesos.constraints` property.
Tested manually by running a spark job by setting the label and node-selector in the mesos box.
BATCHPROC-118 has more details.