### PR TITLE
Make eventlog enablement depend on whether or not event log was provided in spark configs

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -110,7 +110,7 @@ def get_mesos_spark_env(
         # Use \; for multiple constraints, e.g. 'instance_type:m4.10xlarge\;pool:default'
         'spark.mesos.constraints': f'pool:{paasta_pool}',
         'spark.mesos.executor.docker.forcePullImage': 'true',
-        'spark.eventLog.enabled': 'true',
+        'spark.eventLog.enabled': 'true' if event_log_dir else 'false',
     }
     if needs_docker_cfg:
         spark_env['spark.mesos.uris'] = 'file:///root/.dockercfg'
@@ -168,7 +168,7 @@ def get_k8s_spark_env(
         'spark.cores.max': '4',
         'spark.executor.cores': '2',
         'spark.executor.memory': '4g',
-        'spark.eventLog.enabled': 'true',
+        'spark.eventLog.enabled': 'true' if event_log_dir else 'false',
     }
     for i, volume in enumerate(volumes):
         volume_name = i

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -73,12 +73,6 @@ def test_invalid_mem(config_args):
         get_mesos_spark_env(**config_args)
 
 
-def test_no_event_log_dir(config_args):
-    config_args['event_log_dir'] = None
-    with pytest.raises(ValueError):
-        get_mesos_spark_env(**config_args)
-
-
 @pytest.mark.parametrize('shuffle_partitions', [None, 20])
 @pytest.mark.parametrize('needs_docker_cfg', [True, False])
 def test_get_mesos_spark_env(shuffle_partitions, needs_docker_cfg, config_args):
@@ -110,6 +104,13 @@ def test_get_mesos_spark_env(shuffle_partitions, needs_docker_cfg, config_args):
     if needs_docker_cfg:
         expected['spark.mesos.uris'] = 'file:///root/.dockercfg'
     assert spark_env == expected
+
+
+@pytest.mark.parametrize('log_dir,expected', [('/var/log', True), (None, False)])
+def test_get_mesos_spark_env_event_log_dir(config_args, log_dir, expected):
+    config_args['event_log_dir'] = log_dir
+    spark_env = get_mesos_spark_env(**config_args)
+    assert ('spark.eventLog.dir' in spark_env) == expected
 
 
 def test_get_mesos_spark_env_incorrect_file_mode(config_args):
@@ -165,3 +166,10 @@ def test_get_k8s_spark_env(shuffle_partitions, k8s_config_args):
         'spark.kubernetes.node.selector.yelp.com/pool': 'spark-pool',
         'spark.kubernetes.executor.label.yelp.com/pool': 'spark-pool',
     }
+
+
+@pytest.mark.parametrize('log_dir,expected', [('/var/log', True), (None, False)])
+def test_get_k8s_spark_env_event_log_dir(k8s_config_args, log_dir, expected):
+    k8s_config_args['event_log_dir'] = log_dir
+    spark_env = get_k8s_spark_env(**k8s_config_args)
+    assert ('spark.eventLog.dir' in spark_env) == expected


### PR DESCRIPTION
### Description
There are cases in which an event log directory is passed, but because by default we enable event logging, we get a `ValueError` when we attempt to validate spark configs. This is usually not a problem when actually doing spark runs, but it does sometimes break spark job validation in PaaSTA and Tron. This PR turns off event logging if we don't have an event log directory.

### Testing done
`make test`
manual testing on `paasta validate` to verify that this change stops spark job validation in paasta from breaking