### PR TITLE
combined spark functions from paasta and spark_tools

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1,11 +1,35 @@
+import time
 import logging
+import os
+from urllib.parse import urlparse
 from typing import Any
 from typing import List
 from typing import Mapping
 from typing import MutableMapping
 from typing import Optional
+from typing import Tuple
+from typing import Mapping
 
+import boto3
+import json
+import requests
+import yaml
+from boto3 import Session
+
+AWS_CREDENTIALS_DIR = "/etc/boto_cfg/"
+GPU_POOLS_YAML_FILE_PATH = "/nail/srv/configs/gpu_pools.yaml"
+DEFAULT_PAASTA_VOLUME_PATH = "/etc/paasta/volumes.json"
 DEFAULT_SPARK_MESOS_SECRET_FILE = '/nail/etc/paasta_spark_secret'
+DEFAULT_SPARK_RUN_CONFIG = "/nail/srv/configs/spark.yaml"
+DEFAULT_SPARK_SERVICE = "spark"
+GPUS_HARD_LIMIT = 15
+CLUSTERMAN_METRICS_YAML_FILE_PATH = "/nail/srv/configs/clusterman_metrics.yaml"
+DEFAULT_MAX_CORES = 4
+DEFAULT_EXECUTOR_CORES = 2
+DEFAULT_EXECUTOR_INSTANCES = 2
+DEFAULT_EXECUTOR_MEMORY = "4g"
+
+
 NON_CONFIGURABLE_SPARK_OPTS = {
     'spark.master',
     'spark.ui.port',
@@ -37,111 +61,326 @@ K8S_AUTH_FOLDER = '/etc/spark_k8s_secrets'
 log = logging.Logger(__name__)
 
 
-def get_mesos_spark_auth_env() -> Mapping[str, str]:
+def _get_mesos_spark_auth_env(with_secret=False) -> Mapping[str, str]:
     '''Set environment variables needed for spark driver to authenticate to Mesos.
 
     See https://spark.apache.org/docs/latest/running-on-mesos.html#authenticating-to-mesos for
     more details.
     '''
+    if not with_secret:
+        return {
+            'SPARK_MESOS_PRINCIPAL': 'spark',
+            # The actual mesos secret will be decrypted and injected on mesos master when assigning
+            # tasks.
+            'SPARK_MESOS_SECRET': 'SHARED_SECRET(SPARK_MESOS_SECRET)',
+        }
+    try:
+        with open(DEFAULT_SPARK_MESOS_SECRET_FILE, "r") as f:
+            secret = f.read()
+    except IOError as e:
+        log.error(
+            "Cannot load mesos secret from %s" % DEFAULT_SPARK_MESOS_SECRET_FILE,
+        )
+        raise e
     return {
         'SPARK_MESOS_PRINCIPAL': 'spark',
-        # The actual mesos secret will be decrypted and injected on mesos master when assigning
-        # tasks.
-        'SPARK_MESOS_SECRET': 'SHARED_SECRET(SPARK_MESOS_SECRET)',
+        'SPARK_MESOS_SECRET': secret,
     }
 
 
-def _check_non_configurable_spark_opts(user_spark_opts: Mapping[str, Any]) -> None:
-    user_non_config_opts = set(user_spark_opts) & NON_CONFIGURABLE_SPARK_OPTS
-    if (
-        user_non_config_opts or
-        any([
-            spark_opt.startswith('spark.kubernetes.executor.volumes.hostPath')
-            for spark_opt in user_spark_opts.keys()
-        ])
-    ):
-        raise ValueError(f'The following Spark options are not user-configurable: {user_non_config_opts}')
+def _load_aws_credentials_from_yaml(yaml_file_path) -> Tuple[str, str, Optional[str]]:
+    with open(yaml_file_path, "r") as yaml_file:
+        try:
+            credentials_yaml = yaml.safe_load(yaml_file.read())
+            return (
+                credentials_yaml["aws_access_key_id"],
+                credentials_yaml["aws_secret_access_key"],
+                credentials_yaml.get("aws_session_token", None),
+            )
+        except Exception as e:
+            raise ValueError(
+                "Encountered {type(e)} when trying to parse AWS credentials yaml {yaml_file_path}"
+                "Suppressing further output to avoid leaking credentials."
+            )
 
 
-def get_mesos_spark_env(
-    spark_app_name: str,
-    spark_ui_port: str,
-    mesos_leader: str,
+def get_aws_credentials(
+    service: Optional[str] = DEFAULT_SPARK_SERVICE,
+    no_aws_credentials: bool = False,
+    aws_credentials_yaml: Optional[str] = None,
+    profile_name: Optional[str] = None,
+    session: Optional[boto3.Session] = None,
+    aws_credentials_json: Optional[str] = None
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    if no_aws_credentials:
+        return None, None, None
+    elif aws_credentials_yaml:
+        return _load_aws_credentials_from_yaml(aws_credentials_yaml)
+    elif aws_credentials_json:
+        file_type = aws_credentials_json.split(".")[-1]
+        if file_type != "json":
+            raise ValueError("Only json AWS credentials file is supported")
+        with open(aws_credentials_json, "r") as f:
+            creds = json.load(f)
+        return (creds.get("accessKeyId"), creds.get("secretAccessKey"), None)
+    elif service != DEFAULT_SPARK_SERVICE:
+        service_credentials_path = os.path.join(AWS_CREDENTIALS_DIR, f"{service}.yaml")
+        if os.path.exists(service_credentials_path):
+            return _load_aws_credentials_from_yaml(service_credentials_path)
+        elif not session:
+            log.warning(
+                f"Did not find service AWS credentials at {service_credentials_path}. "
+                "Falling back to user credentials."
+            )
+
+    session = session or Session(profile_name=profile_name)
+    creds = session.get_credentials()
+    return (
+        creds.access_key,
+        creds.secret_key,
+        creds.token,
+    )
+
+
+def _pick_random_port(app_name):
+    """Return a random port. """
+    hash_key = f"{app_name}_{time.time()}"
+    hash_number = int(hashlib.sha1(hash_key).hexdigest(), 16)
+    preferred_port = 33000 + (hash_number % 25000)
+    return ephemeral_port_reserve.reserve("0.0.0.0", preferred_port)
+
+
+def _get_docker_volumes_conf(spark_opts: Mapping[str, str], extra_volumes: Optional[List[Mapping[str, str]]] = None) -> dict:
+    """return volume str to be configured for spark.mesos.executor.docker.volume
+    if no extra_volumes and volumes_from_spark_opts, it will read from
+    DEFAULT_PAASTA_VOLUME_PATH and parse it.
+
+    Also spark required to have `/etc/passwd` and `/etc/group` being mounted as
+    well. This will ensure it does have those files in the list.
+    """
+    volumes = spark_opts.get("spark.mesos.executor.docker.volumes", "").split(",")
+
+    if not volumes and extra_volumes is None:
+        with open(DEFAULT_PAASTA_VOLUME_PATH) as fp:
+            extra_volumes = json.load(fp)["volumes"]
+
+    for volume in extra_volumes:  # type: ignore
+        if os.path.exists(volume["hostPath"]):
+            volumes.append(f"{volume['hostPath']}:{volume['containerPath']}:{volume['mode'].lower()}")
+        else:
+            log.warning(f"Path {volume['hostPath']} does not exist on this host. Skipping this bindings.")
+    volume_str = ",".join(set(volumes))  # ensure we don't have duplicated files
+
+    # docker.parameters user needs /etc/passwd and /etc/group to be mounted
+    for required in ["/etc/passwd", "/etc/group"]:
+        if required not in volume_str:
+            volume_str += ",{required}:{required}:ro".format(required=required)
+
+    return {"spark.mesos.executor.docker.volumes": volume_str}
+
+
+def _append_sql_shuffle_partitions_conf(spark_opts):
+    num_partitions = 2 * (
+        int(spark_opts.get("spark.cores.max", 0)) or
+        int(spark_opts.get("spark.executor.instances", 0)) * int(spark_opts.get("spark.executor.cores", 0))
+    )
+    log.warning(
+        f"spark.sql.shuffle.partitions has been set to {num_partitions} "
+        "to be equal to twice the number of requested cores, but you should "
+        "consider setting a higher value if necessary."
+        " Follow y/spark for help on partition sizing"
+    )
+    return {"spark.sql.shuffle.partitions": num_partitions}
+
+
+def _append_event_log_conf(spark_opts: dict, access_key: Optional[str], secret_key: Optional[str], session_token: Optional[str] = None) -> dict:
+    enabled = spark_opts.setdefault("spark.eventLog.enabled", "false").lower()
+
+    if enabled != "true":
+        # user configured to disable log, not continue
+        return spark_opts
+
+    event_log_dir = spark_opts.get("spark.eventLog.dir")
+    if event_log_dir is not None:
+        # we don't want to overwrite user's settings
+        return spark_opts
+
+    try:
+        with open(DEFAULT_SPARK_RUN_CONFIG) as fp:
+            spark_run_conf = yaml.safe_load(fp.read())
+    except Exception as e:
+        log.warning(f"Failed to load {DEFAULT_SPARK_RUN_CONFIG}: {e}, disable event log")
+        return spark_opts
+
+    try:
+        account_id = (
+            boto3.client(
+                "sts",
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                aws_session_token=session_token,
+            )
+            .get_caller_identity()
+            .get("Account")
+        )
+    except Exception as e:
+        log.warning("Failed to identify account ID, error: {}".format(str(e)))
+        return spark_opts
+
+    for conf in spark_run_conf.get("environments", {}).values():
+        if account_id == conf["account_id"]:
+            spark_opts["spark.eventLog.enabled"] = "true"
+            spark_opts["spark.eventLog.dir"] = conf["default_event_log_dir"]
+            return spark_opts
+    return spark_opts
+
+
+def _adjust_spark_requested_resources(user_spark_opts, pool, cluster_manager):
+    executor_memory = user_spark_opts.setdefault("spark.executor.memory", DEFAULT_EXECUTOR_MEMORY)
+    executor_cores = int(user_spark_opts.setdefault("spark.executor.cores", DEFAULT_EXECUTOR_CORES))
+    if cluster_manager  == "mesos":
+        max_cores = int(user_spark_opts.setdefault("spark.cores.max", DEFAULT_MAX_CORES))
+        executor_instances = max_cores / executor_cores
+    elif cluster_manager == "kubernetes":
+        executor_instances = int(user_spark_opts.setdefault("spark.executor.instances", DEFAULT_EXECUTOR_INSTANCES))
+        max_cores = executor_instances * executor_cores
+
+    if max_cores < executor_cores:
+        raise ValueError(f"Total number of cores {max_cores} is less than per-executor cores {executor_cores}")
+
+    memory = parse_memory_string(executor_memory)
+    if memory > 32 * 1024:
+        log.warning("Executor memory is {memory / 32}g, greater than recommended value: 32g")
+
+    num_gpus = int(user_spark_opts.get("spark.mesos.gpus.max", "0"))
+    task_cpus = int(user_spark_opts.get("spark.task.cpus", "1"))
+    executor_cores = int(user_spark_opts.get("spark.executor_cores", "1"))
+    # we can skip this step if user is not using gpu or do not configure
+    # task cpus and executor cores
+    if num_gpus == 0 or (task_cpus != 1 and executor_cores != 1):
+        return user_spark_opts
+
+    if num_gpus != 0 and cluster_manager != "mesos":
+        raise ValueError("spark.mesos.gpus.max is only available for mesos")
+
+    if num_gpus > GPUS_HARD_LIMIT:
+        raise ValueError(
+            "Requested {num_gpus} GPUs, which exceeds hard limit of {GPUS_HARD_LIMIT}"
+        )
+    gpus_per_inst = 0
+    cpus_per_inst = 0
+
+    with open(GPU_POOLS_YAML_FILE_PATH) as fp:
+        pool_def = yaml.safe_load(fp).get(pool)
+
+    if pool_def is not None:
+        gpus_per_inst = int(pool_def["gpus_per_instance"])
+        cpus_per_inst = int(pool_def["cpus_per_instance"])
+        if gpus_per_inst == 0 or cpus_per_inst == 0:
+            raise ValueError(
+                "Unable to adjust spark.task.cpus and spark.executor.cores because "
+                f"pool {pool} does not appear to have any GPUs and/or CPUs"
+            )
+    else:
+        raise ValueError(
+            "Unable to adjust spark.task.cpus and spark.executor.cores because "
+            "pool {pool} not found in gpu_pools"
+        )
+
+    instances = num_gpus // gpus_per_inst
+    if (instances * gpus_per_inst) != num_gpus:
+        raise ValueError(
+            "Unable to adjust spark.task.cpus and spark.executor.cores because "
+            "spark.mesos.gpus.max=%i is not a multiple of %i"
+            % (num_gpus, gpus_per_inst)
+        )
+
+    cpus_per_gpu = cpus_per_inst // gpus_per_inst
+    total_cpus = cpus_per_gpu * num_gpus
+    num_cpus = (
+        int(max_cores) if spark_framework == "mesos"
+        else int(executor_instances) * int(executor_cores)
+    )
+    if num_cpus != total_cpus:
+        log.warning(
+            f"spark.cores.max has been adjusted to {total_cpus}. "
+            "See y/horovod for sizing of GPU pools."
+        )
+
+    user_spark_opts.update({
+        # Mesos limitation - need this to access GPUs
+        "spark.mesos.containerizer": "mesos",
+        # For use by horovod.spark.run(...) in place of num_proc
+        "spark.default.parallelism": str(num_gpus),
+        # we need to adjust the requirements to meet the gpus requriements
+        "spark.task.cpus": str(cpus_per_gpu),
+        "spark.executor.cores": str(cpus_per_gpu * gpus_per_inst),
+        "spark.cores.max": str(total_cpus)
+    })
+    return user_spark_opts
+
+
+def _get_mesos_spark_env(
+    user_spark_opts: Mapping[str, Any],
     paasta_cluster: str,
     paasta_pool: str,
     paasta_service: str,
     paasta_instance: str,
     docker_img: str,
-    volumes: List[str],
-    user_spark_opts: Mapping[str, Any],
-    event_log_dir: Optional[str] = None,
+    extra_volumes: List[Mapping[str, str]],
+    extra_docker_params: Optional[dict] = None,
+    with_secret: bool = True,
     needs_docker_cfg: bool = False,
+    mesos_leader: Optional[str] = None,
 ) -> Mapping[str, str]:
-    _check_non_configurable_spark_opts(user_spark_opts)
 
-    for i, volume in enumerate(volumes):
-        volume_elements = volume.split(':')
-        if len(volume_elements) == 3:
-            volume_elements[-1] = volume_elements[-1].lower()
-            if volume_elements[-1] not in ('rw', 'ro'):
-                raise ValueError(
-                    f'{volume} has incorrect file mode format. Valid formats are rw and ro (lowercased).',
-                )
-            else:
-                volumes[i] = ':'.join(volume_elements)
+    if mesos_leader is None:
+        try:
+            response = requests.get(f"http://paasta-{paasta_cluster}.yelp:5050/redirect")
+        except requests.RequestException:
+            raise ValueError(f"Cannot find spark master for cluster {paasta_cluster}")
+        mesos_leader = f"mesos://{urlparse(response.url).hostname}:5050"
+
+    docker_parameters = [
+        # Limit a container's cpu usage
+        f"cpus={user_spark_opts['spark.executor.cores']}",
+        f"label=paasta_service={paasta_service}",
+        f"label=paasta_instance={paasta_instance}"
+    ]
+    if extra_docker_params:
+        docker_parameters.extend(f"{key}={value}" for key, value in extra_docker_params)
+
     spark_env: MutableMapping[str, str] = {
         'spark.master': f'mesos://{mesos_leader}',
-        'spark.ui.port': spark_ui_port,
         'spark.executorEnv.PAASTA_SERVICE': paasta_service,
         'spark.executorEnv.PAASTA_INSTANCE': paasta_instance,
         'spark.executorEnv.PAASTA_CLUSTER': paasta_cluster,
         'spark.executorEnv.PAASTA_INSTANCE_TYPE': 'spark',
+        "spark.executorEnv.SPARK_USER":  "root",
         'spark.executorEnv.SPARK_EXECUTOR_DIRS': '/tmp',
-        'spark.mesos.executor.docker.parameters':
-            f'label=paasta_service={paasta_service},label=paasta_instance={paasta_instance}',
-        'spark.mesos.executor.docker.volumes': ','.join(volumes),
+        'spark.mesos.executor.docker.parameters': ",".join(docker_parameters),
         'spark.mesos.executor.docker.image': docker_img,
-
-        # User-configurable defaults here
-        'spark.app.name': spark_app_name,
-        'spark.cores.max': '4',
-        'spark.executor.cores': '2',
-        'spark.executor.memory': '4g',
-        # Use \; for multiple constraints, e.g. 'instance_type:m4.10xlarge\;pool:default'
         'spark.mesos.constraints': f'pool:{paasta_pool}',
         'spark.mesos.executor.docker.forcePullImage': 'true',
-        'spark.eventLog.enabled': 'true' if event_log_dir else 'false',
+        **_get_mesos_spark_auth_env(with_secret),
+        **_get_docker_volumes_conf(user_spark_opts, extra_volumes),
     }
     if needs_docker_cfg:
         spark_env['spark.mesos.uris'] = 'file:///root/.dockercfg'
 
-    spark_env = {**spark_env, **user_spark_opts}
-    spark_env['spark.mesos.executor.docker.parameters'] = 'cpus={},{}'.format(
-        spark_env['spark.executor.cores'],
-        spark_env['spark.mesos.executor.docker.parameters'],
-    )
-    _validate_spark_env(spark_env, event_log_dir)
-
     return spark_env
 
 
-def get_k8s_spark_env(
-    spark_app_name: str,
-    spark_ui_port: str,
+def _get_k8s_spark_env(
     paasta_cluster: str,
     paasta_service: str,
     paasta_instance: str,
     docker_img: str,
     volumes: List[Mapping[str, str]],
-    user_spark_opts: Mapping[str, Any],
     paasta_pool: str,
-    event_log_dir: Optional[str] = None,
 ) -> Mapping[str, str]:
-    _check_non_configurable_spark_opts(user_spark_opts)
-
     spark_env: MutableMapping[str, str] = {
         'spark.master': f'k8s://https://k8s.paasta-{paasta_cluster}.yelp:16443',
-        'spark.ui.port': spark_ui_port,
         'spark.executorEnv.PAASTA_SERVICE': paasta_service,
         'spark.executorEnv.PAASTA_INSTANCE': paasta_instance,
         'spark.executorEnv.PAASTA_CLUSTER': paasta_cluster,
@@ -162,13 +401,6 @@ def get_k8s_spark_env(
         'spark.kubernetes.executor.label.paasta.yelp.com/cluster': paasta_cluster,
         'spark.kubernetes.node.selector.yelp.com/pool': paasta_pool,
         'spark.kubernetes.executor.label.yelp.com/pool': paasta_pool,
-
-        # User-configurable defaults here
-        'spark.app.name': spark_app_name,
-        'spark.cores.max': '4',
-        'spark.executor.cores': '2',
-        'spark.executor.memory': '4g',
-        'spark.eventLog.enabled': 'true' if event_log_dir else 'false',
     }
     for i, volume in enumerate(volumes):
         volume_name = i
@@ -177,51 +409,201 @@ def get_k8s_spark_env(
             'true' if volume['mode'].lower() == 'ro' else 'false'
         )
         spark_env[f'spark.kubernetes.executor.volumes.hostPath.{volume_name}.options.path'] = volume['hostPath']
-    spark_env = {**spark_env, **user_spark_opts}
-    _validate_spark_env(spark_env, event_log_dir)
-
     return spark_env
-
-
-def _validate_spark_env(spark_env: MutableMapping[str, str], event_log_dir: Optional[str]) -> None:
-    '''Validate, and possibly modify, values of spark_env
-    '''
-    # spark_opts could be a mix of string and numbers.
-    if int(spark_env['spark.executor.cores']) > int(spark_env['spark.cores.max']):
-        raise ValueError(
-            'spark.executor.cores={executor_cores} should be not greater than spark.cores.max={max_cores}'.format(
-                executor_cores=spark_env['spark.executor.cores'],
-                max_cores=spark_env['spark.cores.max'],
-            ),
-        )
-
-    if not spark_env.get('spark.sql.shuffle.partitions'):
-        spark_env['spark.sql.shuffle.partitions'] = str(2 * int(spark_env['spark.cores.max']))
-        log.warning(
-            'spark.sql.shuffle.partitions has been set to {num_partitions} '
-            'to be equal to twice the number of requested cores, but you should '
-            'consider setting a higher value if necessary.'
-            ' Follow y/spark for help on partition sizing'.format(
-                num_partitions=spark_env['spark.sql.shuffle.partitions'],
-            ),
-        )
-
-    if spark_env['spark.eventLog.enabled'] == 'true':
-        if not spark_env.get('spark.eventLog.dir'):
-            if not event_log_dir:
-                raise ValueError('Asked for event logging but spark.eventLog.dir missing')
-            spark_env['spark.eventLog.dir'] = event_log_dir
-        log.info(f'Spark event logs available in {event_log_dir}')
-
-    exec_mem = spark_env['spark.executor.memory']
-    if exec_mem[-1] != 'g' or not exec_mem[:-1].isdigit():
-        raise ValueError('Executor memory {} not in format dg.'.format(spark_env['spark.executor.memory']))
-    if int(exec_mem[:-1]) > 32:
-        log.warning(
-            f'You have specified a large amount of memory ({exec_mem[:-1]} > 32g); '
-            f'please make sure that you actually need this much, or reduce your memory requirements',
-        )
 
 
 def stringify_spark_env(spark_env: Mapping[str, str]) -> str:
     return ' '.join([f'--conf {k}={v}' for k, v in spark_env.items()])
+
+
+def _filter_user_spark_opts(user_spark_opts):
+    non_configurable_opts = set(user_spark_opts.keys()) - set(NON_CONFIGURABLE_SPARK_OPTS)
+    if non_configurable_opts:
+        log.warning(f"The following options are configured by Paasta: {non_configurable_opts} instead")
+    return {
+        key: value
+        for key, value in user_spark_opts.items()
+        if key not in NON_CONFIGURABLE_SPARK_OPTS
+    }
+
+def get_spark_conf(
+    cluster_manager: str,
+    spark_app_base_name: str,
+    user_spark_opts: Mapping[str, Any],
+    paasta_cluster: str,
+    paasta_pool: str,
+    paasta_service: str,
+    paasta_instance: str,
+    docker_img: str,
+    extra_volumes: List[Mapping[str, str]],
+    aws_creds: Tuple[Optional[str], Optional[str], Optional[str]],
+    # the follow arguments only being used for mesos
+    extra_docker_params: Optional[dict] = None,
+    with_secret: bool = True,
+    needs_docker_cfg: bool = False,
+    mesos_leader: Optional[str]=None,
+    spark_opts_from_env: Optional[Mapping[str, str]]=None,
+):
+    app_base_name = (
+        user_spark_opts.get("spark.app.name")
+        or (spark_opts_from_env or {}).get("spark.app.name")
+        or spark_app_base_name
+    )
+
+    ui_port = (spark_opts_from_env or {}).get("spark.ui.port") or _pick_random_port(
+        app_base_name + str(time.time())
+    )
+
+    # app_name from env is already appended port and time to make it unique
+    app_name = (spark_opts_from_env or {}).get("spark.app.name")
+    if not app_name:
+        # We want to make the app name more unique so that we can search it
+        # from history server.
+        app_name = f"{spark_app_base_name}_{ui_port}_{int(time.time())}"
+
+    spark_conf = {**(spark_opts_from_env or {}), **_filter_user_spark_opts(user_spark_opts)}
+
+    spark_conf.update({
+        'spark.app.name': app_name,
+        'spark.ui.port': ui_port,
+    })
+
+   # adjusted with spark default resources
+    spark_conf = _adjust_spark_requested_resources(spark_conf, paasta_pool, cluster_manager)
+
+    if cluster_manager == "mesos":
+        spark_conf.update(_get_mesos_spark_env(
+            spark_conf,
+            paasta_cluster,
+            paasta_pool,
+            paasta_service,
+            paasta_instance,
+            docker_img,
+            extra_volumes,
+            extra_docker_params,
+            with_secret,
+            needs_docker_cfg,
+            mesos_leader
+        ))
+    elif cluster_manager == "kubernetes":
+        spark_conf.update(_get_k8s_spark_env(
+            paasta_cluster,
+            paasta_service,
+            paasta_instance,
+            docker_img,
+            extra_volumes,
+            paasta_pool
+        ))
+    else:
+        raise ValueError("Unknown resource_manager, should be either [mesos,kubernetes]")
+
+    # configure spark_event_log
+    spark_conf = _append_event_log_conf(spark_conf, *aws_creds)
+
+    # configure sql shuffle partitions
+    spark_conf = _append_sql_shuffle_partitions_conf(spark_conf)
+    return spark_conf
+
+
+def parse_memory_string(memory_string):
+    return (
+        int(memory_string[:-1]) * 1024 if memory_string.endswith("g")
+        else int(memory_string)
+    )
+
+
+def get_signalfx_url(spark_conf:Mapping[str, str]) -> str:
+    return (
+        "https://app.signalfx.com/#/dashboard/DJzYJDkAcAA?density=4"
+        "&variables%5B%5D=Instance%3Dinstance_name:"
+        "&variables%5B%5D=Service%3Dservice_name:%5B%22spark%22%5D"
+        f"&variables%5B%5D=PaaSTA%20Cluster%3Dpaasta_cluster:{spark_conf['spark.executorEnv.PAASTA_CLUSTER']}"
+        f"&variables%5B%5D=PaaSTA%20Service%3Dpaasta_service:{spark_conf['spark.executorEnv.PAASTA_SERVICE']}"
+        f"&variables%5B%5D=PaaSTA%20Instance%3Dpaasta_instance:{spark_conf['spark.executorEnv.PAASTA_INSTANCE']}"
+        "&startTime=-6h&endTime=Now"
+    )
+
+
+def get_history_url(spark_conf:Mapping[str, str]) -> Optional[str]:
+    if spark_conf.get("spark.eventLog.enabled") != "true":
+        return None
+    event_log_dir = spark_conf.get("spark.eventLog.dir")
+    with open(DEFAULT_SPARK_RUN_CONFIG) as fp:
+        spark_run_conf = yaml.safe_load(fp.read())
+    for env, env_conf in spark_run_conf["environments"].items():
+        if event_log_dir == env_conf["default_event_log_dir"]:
+            return env_conf["history_server"]
+    return None
+
+
+def get_clusterman_resource_requirements(spark_opts: Mapping[str, str]) -> Mapping[str, int]:
+    num_executors = (
+        # spark on k8s directly configure num instances
+        int(spark_opts.get("spark.executor.instances", 0)) or
+        # spark on mesos use cores.max and executor.core to calculate number of
+        # executors.
+        int(spark_opts.get("spark.cores.max", 0)) / int(spark_opts.get("spark.executor.cores", 0))
+    )
+    num_cpus = (
+        # spark on k8s
+        int(spark_opts.get("spark.executor.instances", 0)) * int(spark_opts.get("spark.executor.cores", 0)) or
+        # spark on mesos
+        int(spark_opts.get("spark.cores.max", 0))
+    )
+    num_gpus = int(spark_opts.get("spark.mesos.gpus.max", 0))
+
+    executor_memory = parse_memory_string(spark_opts.get("spark.executor.memory", ""))
+    # by default, spark adds an overhead of 10% of the executor memory, with a
+    # minimum of 384mb
+    memory_overhead = (
+        parse_memory_string(spark_opts["spark.executor.memory_overhead"])
+        if spark_opts.get("spark.executor.memoryOverhead")
+        else max(384, int(0.1 * executor_memory))
+    )
+    total_memory = (executor_memory + memory_overhead) * num_executors
+
+    return {
+        "cpus": num_cpus,
+        "mem": total_memory,
+        # rough guess since spark does not collect this information
+        "disk": total_memory,
+        "gpus": num_gpus,
+    }
+
+def _emit_resource_requirements(resources, app_name, spark_web_url, cluster, pool):
+    dimensions = {
+        "framework_name": app_name,
+        "webui_url": spark_web_url,
+    }
+
+    with metrics_client(cluster, pool).get_writer(
+        clusterman_metrics.APP_METRICS, aggregate_meteorite_dims=True
+    ) as writer:
+        for resource, required_quantity in resources.items():
+            metric_key = clusterman_metrics.generate_key_with_dimensions(
+                "requested_{resource}".format(resource=resource), dimensions
+            )
+            writer.send((metric_key, int(time.time()), required_quantity))
+
+
+def _get_spark_hourly_cost(resources, cluster, pool):
+    cpus = resources["cpus"]
+    mem = resources["mem"]
+    return metrics_client(cluster, pool).util.costs.estimate_cost_per_hour(
+        cluster=paasta_cluster, pool=pool, cpus=cpus, mem=mem,
+    )
+
+
+def send_and_calculate_resources_cost(
+    spark_conf: Mapping[str, str],
+    spark_web_url: str,
+):
+    cluster = spark_conf["spark.executorEnv.PAASTA_CLUSTER"],
+    pool = spark_conf["spark.executorEnv.PAASTA_POOL"]
+    app_name = spark_conf["spark.app.name"]
+    resources = get_clusterman_resource_requirements(spark_conf)
+    hourly_cost = _get_spark_hourly_cost(resources, cluster, pool)
+    _emit_resource_requirements(
+        resources, app_name, spark_web_url, cluster, pool
+    )
+    return hourly_cost, resources

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'PyYAML >= 5.1',
         'pyinotify',
         'requests>=2.18.4',
+        'boto3',
     ],
     license='Copyright Yelp 2013, All Rights Reserved',
     scripts=[

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         'pyinotify',
         'requests>=2.18.4',
         'boto3',
-        'clusterman_metrics',
     ],
     license='Copyright Yelp 2013, All Rights Reserved',
     scripts=[

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.4.7',
+    version='2.5.0',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'pyinotify',
         'requests>=2.18.4',
         'boto3',
+        'clusterman_metrics',
     ],
     license='Copyright Yelp 2013, All Rights Reserved',
     scripts=[

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -1,175 +1,1001 @@
+import json
+import os
+from unittest import mock
+
 import pytest
+import yaml
 
-from service_configuration_lib.spark_config import get_k8s_spark_env
-from service_configuration_lib.spark_config import get_mesos_spark_auth_env
-from service_configuration_lib.spark_config import get_mesos_spark_env
+from service_configuration_lib import spark_config
 
-
-@pytest.fixture
-def config_args():
-    return dict(
-        spark_app_name='my-spark-app',
-        spark_ui_port='1234',
-        mesos_leader='the-mesos-leader:5050',
-        paasta_cluster='westeros-devc',
-        paasta_pool='spark-pool',
-        paasta_service='spark-service',
-        paasta_instance='batch',
-        docker_img='docker-dev.nowhere.com/spark:latest',
-        volumes=['/nail/var:/nail/var:ro', '/etc/foo:/etc/foo:RO'],
-        user_spark_opts={},
-        event_log_dir='/var/log',
-    )
+TEST_ACCOUNT_ID = '123456789'
 
 
 @pytest.fixture
-def k8s_config_args():
-    return dict(
-        spark_app_name='my-spark-app',
-        spark_ui_port='1234',
-        paasta_cluster='westeros-devc',
-        paasta_service='spark-service',
-        paasta_instance='batch',
-        paasta_pool='spark-pool',
-        docker_img='docker-dev.nowhere.com/spark:latest',
-        user_spark_opts={},
-        event_log_dir='/var/log',
-        volumes=[
-            {
-                'hostPath': '/nail/etc/beep',
-                'containerPath': '/nail/etc/beep',
-                'mode': 'RO',
+def mock_log(monkeypatch):
+    mock_log = mock.Mock()
+    monkeypatch.setattr(spark_config, 'log', mock_log)
+    return mock_log
+
+
+@pytest.fixture
+def mock_spark_run_conf(tmpdir, monkeypatch):
+    spark_run_conf = {
+        'environments': {
+            'testing': {
+                'account_id': TEST_ACCOUNT_ID,
+                'default_event_log_dir': 's3a://test/eventlog',
+                'history_server': 'https://spark-history-testing',
             },
-            {
-                'hostPath': '/nail/etc/bop',
-                'containerPath': '/nail/etc/bop',
-                'mode': 'RW',
-            },
+        },
+    }
+    fp = tmpdir.join('spark_run.yaml')
+    fp.write(yaml.dump(spark_run_conf))
+    monkeypatch.setattr(spark_config, 'DEFAULT_SPARK_RUN_CONFIG', str(fp))
+    return spark_run_conf
+
+
+@pytest.fixture
+def mock_time():
+    with mock.patch.object(spark_config.time, 'time', return_value=123.456):
+        yield 123.456
+
+
+class TestGetAWSCredentials:
+
+    access_key = 'test_key'
+    secret_key = 'test_secret'
+    session_token = 'test_token'
+
+    temp_creds = {
+        'aws_access_key_id': access_key,
+        'aws_secret_access_key': secret_key,
+        'aws_session_token': session_token,
+    }
+    expected_temp_creds = (access_key, secret_key, session_token)
+
+    creds = {'aws_access_key_id': access_key, 'aws_secret_access_key': secret_key}
+    expected_creds = (access_key, secret_key, None)
+
+    def test_no_aws_creds(self):
+        assert spark_config.get_aws_credentials(no_aws_credentials=True) == (None, None, None)
+
+    @pytest.mark.parametrize('aws_creds', [temp_creds, creds])
+    def test_aws_credentials_yaml(self, tmpdir, aws_creds):
+        fp = tmpdir.join('test.yaml')
+        fp.write(yaml.dump(aws_creds))
+        expected_output = self.expected_temp_creds if aws_creds == self.temp_creds else self.expected_creds
+        assert spark_config.get_aws_credentials(aws_credentials_yaml=str(fp)) == expected_output
+
+    def test_use_service_credentials(self, tmpdir, monkeypatch):
+        test_service = 'test_service'
+        creds_dir = tmpdir.mkdir('creds')
+        creds_file = creds_dir.join(f'test_service.yaml')
+        creds_file.write(yaml.dump(self.creds))
+        monkeypatch.setattr(spark_config, 'AWS_CREDENTIALS_DIR', str(creds_dir))
+        assert spark_config.get_aws_credentials(service=test_service) == self.expected_creds
+
+    @pytest.fixture
+    def mock_session(self):
+        mock_session = mock.Mock()
+        with mock.patch.object(spark_config, 'Session', return_value=mock_session):
+            mock_session.get_credentials.return_value = mock.Mock(
+                access_key=self.access_key,
+                secret_key=self.secret_key,
+                token=self.session_token,
+            )
+            yield mock_session
+
+    def test_use_service_credentials_missing_file(self, tmpdir, monkeypatch, mock_session, mock_log):
+        test_service = 'not_exist'
+        creds_dir = tmpdir.mkdir('creds')
+        monkeypatch.setattr(spark_config, 'AWS_CREDENTIALS_DIR', str(creds_dir))
+        assert spark_config.get_aws_credentials(service=test_service) == self.expected_temp_creds
+        (warning_msg,), _ = mock_log.warning.call_args
+        expected_message = f"Did not find service AWS credentials at {os.path.join(creds_dir, test_service + '.yaml')}"
+        assert expected_message in warning_msg
+
+    def test_use_session(self, mock_session):
+        assert spark_config.get_aws_credentials(session=mock_session) == self.expected_temp_creds
+
+    def test_use_aws_credentials_json(self, tmpdir):
+        fp = tmpdir.join('test.json')
+        fp.write(json.dumps({'accessKeyId': self.access_key, 'secretAccessKey': self.secret_key}))
+        assert spark_config.get_aws_credentials(aws_credentials_json=str(fp)) == self.expected_creds
+
+    def test_use_profile(self, mock_session):
+        assert spark_config.get_aws_credentials(profile_name='test_profile') == self.expected_temp_creds
+
+    def test_fail(self, tmpdir):
+        fp = tmpdir.join('test.yaml')
+        fp.write('not yaml file')
+        with pytest.raises(ValueError):
+            spark_config.get_aws_credentials(aws_credentials_yaml=str(fp))
+
+
+def test_pick_random_port():
+    with mock.patch('ephemeral_port_reserve.reserve') as mock_reserve:
+        port = spark_config._pick_random_port('test')
+        (host, prefer_port), _ = mock_reserve.call_args
+        assert host == '0.0.0.0'
+        assert prefer_port >= 33000
+        assert port == mock_reserve.return_value
+
+
+class MockConfigFunction:
+
+    def __init__(self, mock_func, return_value):
+        self.return_value = return_value
+
+        def side_effect(*args, **kwargs):
+            return {**args[0], **self.return_value}
+        self._patch = mock.patch.object(spark_config, mock_func, side_effect=side_effect)
+
+    def __enter__(self):
+        self.mocker = self._patch.__enter__()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self._patch.__exit__(*args, **kwargs)
+
+
+class TestGetSparkConf:
+    cluster = 'test-cluster'
+    service = 'test-service'
+    instance = 'test-instance'
+    pool = 'test-pool'
+    docker_image = 'docker-dev.yelp.com/test-image'
+    executor_cores = '10'
+    spark_app_base_name = 'test_app_base_name'
+    extra_volumes = [{'hostPath': '/tmp', 'containerPath': '/tmp', 'mode': 'RO'}]
+    default_mesos_leader = 'mesos://some-url.yelp.com:5050'
+
+    @pytest.fixture
+    def mock_paasta_volumes(self, monkeypatch, tmpdir):
+        files = [f'paasta{i + 1}' for i in range(2)]
+        volumes = [
+            {'hostPath': f'/host/{f}', 'containerPath': f'/container/{f}', 'mode': 'RO'}
+            for i, f in enumerate(files)
+        ]
+        fp = tmpdir.join('volumes.json')
+        fp.write(json.dumps({'volumes': volumes}))
+        monkeypatch.setattr(spark_config, 'DEFAULT_PAASTA_VOLUME_PATH', str(fp))
+        return [f'/host/{f}:/container/{f}:ro' for f in files]
+
+    @pytest.fixture
+    def mock_existed_files(self, mock_paasta_volumes):
+        existed_files = [v.split(':')[0] for v in mock_paasta_volumes] + ['/host/file1', '/host/file2', '/host/file3']
+        with mock.patch('os.path.exists', side_effect=lambda f: f in existed_files):
+            yield existed_files
+
+    @pytest.mark.parametrize(
+        'original_volumes', [
+            None,
+            [
+                '/host/file1:/containter/file1:ro',
+                '/host/file2:/containter/file2:ro',
+                '/host/paasta1:/container/paasta1:ro',
+            ],
         ],
     )
+    @pytest.mark.parametrize('load_paasta_volumes', [True, False])
+    @pytest.mark.parametrize(
+        'extra_volumes', [
+            None,
+            [
+                {'hostPath': '/host/file1', 'containerPath': '/container/file1', 'mode': 'RO'},
+                {'hostPath': '/host/file3', 'containerPath': '/container/file3', 'mode': 'RW'},
+                {'hostPath': '/host/not_exist', 'containerPath': '/container/not_exist', 'mode': 'RW'},
+            ],
+        ],
+    )
+    def test_get_mesos_docker_volumes_conf(
+        self,
+        load_paasta_volumes,
+        original_volumes,
+        extra_volumes,
+        mock_existed_files,
+        mock_paasta_volumes,
+    ):
+        validate_key = 'spark.mesos.executor.docker.volumes'
+        expected_volumes = [
+            '/etc/passwd:/etc/passwd:ro', '/etc/group:/etc/group:ro',
+        ]
+        if load_paasta_volumes:
+            expected_volumes.extend(mock_paasta_volumes)
+        if original_volumes:
+            expected_volumes.extend(original_volumes)
+        if extra_volumes:
+            expected_volumes.extend([
+                f"{v['hostPath']}:{v['containerPath']}:{v['mode'].lower()}"
+                for v in extra_volumes
+                if v['hostPath'] in mock_existed_files
+            ])
+
+        spark_conf = {validate_key: ','.join(original_volumes)} if original_volumes else {}
+
+        output = spark_config._get_mesos_docker_volumes_conf(
+            spark_conf, extra_volumes, load_paasta_volumes,
+        )
+        assert sorted(output[validate_key].split(',')) == sorted(set(expected_volumes))
+
+    @pytest.fixture
+    def mock_account_id(self, tmpdir, monkeypatch):
+        def get_client(service_name, **kwargs):
+            if (
+                kwargs.get('aws_access_key_id') != 'prod_key' or
+                kwargs.get('aws_secret_access_key') != 'prod_secret'
+            ):
+                raise Exception('Unknown key')
+
+            mock_client = mock.Mock()
+            mock_get = mock_client.get_caller_identity().get
+            mock_get.side_effect = lambda x: TEST_ACCOUNT_ID if x == 'Account' else None
+            return mock_client
+
+        with mock.patch.object(spark_config.boto3, 'client', side_effect=get_client):
+            yield
+
+    @pytest.fixture
+    def gpu_pool(self, tmpdir, monkeypatch):
+        pools_def = {
+            'test_gpu_pool': {
+                'gpus_per_instance': 1,
+                'cpus_per_instance': 8,
+                'memory_per_instance': 1024,
+            },
+        }
+        fp = tmpdir.join('gpu_pools.yaml')
+        fp.write(yaml.dump(pools_def))
+        monkeypatch.setattr(spark_config, 'GPU_POOLS_YAML_FILE_PATH', str(fp))
+        return pools_def
+
+    @pytest.mark.parametrize(
+        'cluster_manager,user_spark_opts,expected_output', [
+            # use default k8s settings
+            (
+                'kubernetes',
+                {},
+                {'spark.executor.memory': '4g', 'spark.executor.cores': '2', 'spark.executor.instances': '2'},
+            ),
+            # use default mesos settings
+            (
+                'mesos',
+                {},
+                {
+                    'spark.executor.memory': '4g',
+                    'spark.executor.cores': '2',
+                    'spark.cores.max': '4',
+                },
+            ),
+            # user defined resources
+            (
+                'mesos',
+                {
+                    'spark.executor.memory': '2g',
+                    'spark.executor.cores': '4',
+                    'spark.cores.max': '12',
+                },
+                {
+                    'spark.executor.memory': '2g',
+                    'spark.executor.cores': '4',
+                    'spark.cores.max': '12',
+                },
+            ),
+            # gpu with default settings
+            (
+                'mesos',
+                {'spark.mesos.gpus.max': '2'},
+                {
+                    'spark.mesos.gpus.max': '2',
+                    'spark.mesos.containerizer': 'mesos',
+                    'spark.default.parallelism': '2',
+                    'spark.task.cpus': '8',
+                    'spark.executor.cores': '8',
+                    'spark.executor.memory': '4g',
+                    'spark.cores.max': '16',
+                },
+            ),
+            # Gpu with user defined resources
+            (
+                'mesos',
+                {
+                    'spark.mesos.gpus.max': '2',
+                    'spark.task.cpus': '2',
+                    'spark.executor.cores': '4',
+                },
+                {
+                    'spark.mesos.gpus.max': '2',
+                    'spark.task.cpus': '2',
+                    'spark.executor.cores': '4',
+                    'spark.cores.max': '4',
+                },
+            ),
+        ],
+    )
+    def test_adjust_spark_requested_resources(
+        self,
+        cluster_manager,
+        user_spark_opts,
+        expected_output,
+        gpu_pool,
+    ):
+        pool = (
+            'test-batch-pool'
+            if user_spark_opts.get('spark.mesos.gpus.max', '0') == '0'
+            else next(iter(gpu_pool.keys()))
+        )
+        output = spark_config._adjust_spark_requested_resources(
+            user_spark_opts, cluster_manager, pool,
+        )
+        for key in expected_output:
+            assert output[key] == expected_output[key]
+
+    @pytest.mark.parametrize(
+        'cluster_manager,spark_opts,pool', [
+            # max_cores < executor_core
+            ('mesos', {'spark.cores.max': '10', 'spark.executor.cores': '20'}, pool),
+            # use gpu with kubernetes
+            ('kubernetes', {'spark.mesos.gpus.max': '10'}, pool),
+            # gpu over limit
+            ('mesos', {'spark.mesos.gpus.max': str(spark_config.GPUS_HARD_LIMIT + 1)}, pool),
+            # pool not found
+            ('mesos', {'spark.mesos.gpus.max': '2'}, 'not_exist_pool'),
+        ],
+    )
+    def test_adjust_spark_requested_resources_error(
+        self,
+        cluster_manager,
+        spark_opts,
+        pool,
+        gpu_pool,
+    ):
+        with pytest.raises(ValueError):
+            spark_config._adjust_spark_requested_resources(spark_opts, cluster_manager, pool)
+
+    @pytest.mark.parametrize(
+        'user_spark_opts,aws_creds,expected_output', [
+            # user specified to disable
+            (
+                {'spark.eventLog.enabled': 'false'},
+                (None, None, None),
+                {'spark.eventLog.enabled': 'false'},
+            ),
+            # user specified their own bucket
+            (
+                {
+                    'spark.eventLog.enabled': 'true',
+                    'spark.eventLog.dir': 's3a://other/bucket',
+                },
+                (None, None, None),
+                {
+                    'spark.eventLog.enabled': 'true',
+                    'spark.eventLog.dir': 's3a://other/bucket',
+                },
+            ),
+            # use predefined bucket
+            (
+                {},
+                ('prod_key', 'prod_secret', None),
+                {
+                    'spark.eventLog.enabled': 'true',
+                    'spark.eventLog.dir': 's3a://test/eventlog',
+                },
+            ),
+            # no predefined bucket available
+            (
+                {},
+                ('different_key', 'different_secret', 'different'),
+                {'spark.eventLog.enabled': 'false'},
+            ),
+        ],
+    )
+    def test_append_event_log_conf(
+        self,
+        mock_spark_run_conf,
+        mock_account_id,
+        user_spark_opts,
+        aws_creds,
+        expected_output,
+    ):
+        output = spark_config._append_event_log_conf(user_spark_opts, *aws_creds)
+        for key in expected_output:
+            assert output[key] == expected_output[key]
+
+    @pytest.mark.parametrize(
+        'user_spark_opts,expected_output', [
+            # mesos
+            ({'spark.cores.max': '10'}, '20'),
+            # k8s
+            ({'spark.executor.instances': '10', 'spark.executor.cores': '3'}, '60'),
+            # user defined
+            ({'spark.sql.shuffle.partitions': '300'}, '300'),
+        ],
+    )
+    def test_append_sql_shuffle_partitions_conf(
+        self, user_spark_opts, expected_output,
+    ):
+        output = spark_config._append_sql_shuffle_partitions_conf(user_spark_opts)
+        key = 'spark.sql.shuffle.partitions'
+        assert output[key] == expected_output
+
+    @pytest.fixture
+    def mock_get_mesos_docker_volumes_conf(self):
+        return_value = {'spark.mesos.executor.docker.volumes': '/tmp:/tmp:ro'}
+        with MockConfigFunction('_get_mesos_docker_volumes_conf', return_value) as m:
+            yield m
+
+    @pytest.fixture
+    def mock_append_sql_shuffle_partitions_conf(self):
+        return_value = {'spark.sql.shuffle.partitions': '10'}
+        with MockConfigFunction(
+            '_append_sql_shuffle_partitions_conf', return_value,
+        ) as m:
+            yield m
+
+    @pytest.fixture
+    def mock_append_event_log_conf(self):
+        return_value = {
+            'spark.eventLog.enabled': 'true',
+            'spark.eventLog.dir': 's3a://test/bucket/',
+        }
+        with MockConfigFunction('_append_event_log_conf', return_value) as m:
+            yield m
+
+    @pytest.fixture
+    def mock_adjust_spark_requested_resources_mesos(self):
+        return_value = {
+            'spark.cores.max': '10',
+            'spark.executor.cores': self.executor_cores,
+            'spark.executor.memory': '2g',
+        }
+        with MockConfigFunction('_adjust_spark_requested_resources', return_value) as m:
+            yield m
+
+    @pytest.fixture
+    def mock_adjust_spark_requested_resources_kubernetes(self):
+        return_value = {
+            'spark.cores.instances': '2',
+            'spark.executor.cores': self.executor_cores,
+            'spark.executor.memory': '2g',
+        }
+        with MockConfigFunction('_adjust_spark_requested_resources', return_value) as m:
+            yield m
+
+    @pytest.fixture
+    def mock_secret(self, tmpdir, monkeypatch):
+        secret = 'secret'
+        fp = tmpdir.join('mesos_secret')
+        fp.write(secret)
+        monkeypatch.setattr(spark_config, 'DEFAULT_SPARK_MESOS_SECRET_FILE', str(fp))
+        return secret
+
+    @pytest.fixture(params=[False, True])
+    def with_secret(self, request):
+        return request.param
+
+    @pytest.fixture
+    def assert_mesos_secret(self, with_secret, mock_secret):
+        expected_output = mock_secret if with_secret else None
+
+        def verify(output):
+            if expected_output:
+                key = 'spark.mesos.secret'
+                assert output[key] == mock_secret
+                return [key]
+            return []
+        return verify
+
+    @pytest.fixture
+    def mock_request_mesos_leader(self):
+        return_value = self.default_mesos_leader.replace('mesos://', 'http://') + '/#/'
+        with mock.patch.object(spark_config.requests, 'get') as m:
+            m.return_value = mock.Mock(url=return_value)
+            yield m
+
+    @pytest.fixture(params=[None, 'test-mesos:5050'])
+    def mesos_leader(self, request):
+        return request.param
+
+    @pytest.fixture
+    def assert_mesos_leader(self, mesos_leader, mock_request_mesos_leader):
+        expected_output = f'mesos://{mesos_leader}' if mesos_leader else self.default_mesos_leader
+
+        def validate(output):
+            key = 'spark.master'
+            assert output[key] == expected_output
+            return [key]
+
+        return validate
+
+    @pytest.fixture(params=[None, {'workdir': '/tmp'}])
+    def extra_docker_params(self, request):
+        return request.param
+
+    @pytest.fixture
+    def assert_docker_parameters(self, extra_docker_params):
+        def verify(output):
+            expected_output = (
+                f'cpus={self.executor_cores},'
+                f'label=paasta_service={self.service},'
+                f'label=paasta_instance={self.instance}'
+            )
+            if extra_docker_params:
+                for key, value in extra_docker_params.items():
+                    expected_output += f',{key}={value}'
+
+            key = 'spark.mesos.executor.docker.parameters'
+            assert output[key] == expected_output
+            return [key]
+        return verify
+
+    @pytest.fixture(params=[False, True])
+    def needs_docker_cfg(self, request):
+        return request.param
+
+    @pytest.fixture
+    def assert_docker_cfg(self, needs_docker_cfg):
+        def verify(output):
+            if needs_docker_cfg:
+                key = 'spark.mesos.uris'
+                assert output[key] == 'file:///root/.dockercfg'
+                return [key]
+            return []
+        return verify
+
+    @pytest.fixture
+    def mock_pick_random_port(self):
+        port = '12345'
+        with mock.patch.object(spark_config, '_pick_random_port', return_value=port):
+            yield port
+
+    @pytest.fixture(params=[None, '23456'])
+    def ui_port(self, request, mock_pick_random_port):
+        return request.param
+
+    @pytest.fixture(params=[None, 'test_app_name_from_env'])
+    def spark_opts_from_env(self, request, ui_port):
+        spark_opts = {}
+        if ui_port:
+            spark_opts['spark.ui.port'] = ui_port
+        if request.param:
+            spark_opts['spark.app.name'] = request.param
+        return spark_opts or None
+
+    @pytest.fixture
+    def assert_ui_port(self, spark_opts_from_env, ui_port, mock_pick_random_port):
+        expected_output = ui_port if ui_port else mock_pick_random_port
+
+        def verify(output):
+            key = 'spark.ui.port'
+            assert output[key] == expected_output
+            return [key]
+        return verify
+
+    @pytest.fixture(params=[None, {'spark.app.name': 'app_base_name_from_spark_opts'}])
+    def user_spark_opts(self, request):
+        return request.param
+
+    @pytest.fixture
+    def assert_app_name(self, spark_opts_from_env, user_spark_opts, ui_port, mock_pick_random_port):
+        expected_output = (spark_opts_from_env or {}).get('spark.app.name')
+        if not expected_output:
+            expected_output = (
+                (user_spark_opts or {}).get('spark.app.name') or
+                self.spark_app_base_name
+            ) + '_' + (ui_port or mock_pick_random_port) + '_123'
+
+        def verify(output):
+            key = 'spark.app.name'
+            assert output[key] == expected_output
+            return [key]
+        return verify
+
+    @pytest.fixture
+    def assert_mesos_conf(self):
+        def verify(output):
+            expected_output = {
+                'spark.executorEnv.PAASTA_SERVICE': self.service,
+                'spark.executorEnv.PAASTA_INSTANCE': self.instance,
+                'spark.executorEnv.PAASTA_CLUSTER': self.cluster,
+                'spark.executorEnv.PAASTA_INSTANCE_TYPE': 'spark',
+                'spark.executorEnv.SPARK_USER': 'root',
+                'spark.executorEnv.SPARK_EXECUTOR_DIRS': '/tmp',
+                'spark.mesos.executor.docker.image': self.docker_image,
+                'spark.mesos.executor.docker.forcePullImage': 'true',
+                'spark.mesos.constraints': f'pool:{self.pool}',
+                'spark.mesos.principal': 'spark',
+            }
+            for key, value in expected_output.items():
+                assert output[key] == value
+            return list(expected_output.keys())
+
+        return verify
+
+    def test_get_spark_conf_mesos(
+        self,
+        user_spark_opts,
+        spark_opts_from_env,
+        ui_port,
+        with_secret,
+        mesos_leader,
+        needs_docker_cfg,
+        extra_docker_params,
+        mock_get_mesos_docker_volumes_conf,
+        mock_append_event_log_conf,
+        mock_append_sql_shuffle_partitions_conf,
+        mock_adjust_spark_requested_resources_mesos,
+        mock_time,
+        assert_mesos_leader,
+        assert_docker_parameters,
+        assert_mesos_secret,
+        assert_docker_cfg,
+        assert_mesos_conf,
+        assert_ui_port,
+        assert_app_name,
+        mock_log,
+    ):
+        other_spark_opts = {'spark.driver.memory': '2g', 'spark.executor.memoryOverhead': '1024'}
+        not_allowed_opts = {'spark.executorEnv.PAASTA_SERVICE': 'random-service'}
+        user_spark_opts = {
+            **(user_spark_opts or {}),
+            **not_allowed_opts,
+            **other_spark_opts,
+        }
+
+        aws_creds = (None, None, None)
+
+        output = spark_config.get_spark_conf(
+            cluster_manager='mesos',
+            spark_app_base_name=self.spark_app_base_name,
+            user_spark_opts=user_spark_opts,
+            paasta_cluster=self.cluster,
+            paasta_pool=self.pool,
+            paasta_service=self.service,
+            paasta_instance=self.instance,
+            docker_img=self.docker_image,
+            extra_volumes=self.extra_volumes,
+            aws_creds=aws_creds,
+            extra_docker_params=extra_docker_params,
+            with_secret=with_secret,
+            needs_docker_cfg=needs_docker_cfg,
+            mesos_leader=mesos_leader,
+            spark_opts_from_env=spark_opts_from_env,
+            load_paasta_default_volumes=True,
+        )
+
+        verified_keys = set(
+            assert_mesos_leader(output) +
+            assert_docker_parameters(output) +
+            assert_mesos_secret(output) +
+            assert_docker_cfg(output) +
+            assert_mesos_conf(output) +
+            assert_ui_port(output) +
+            assert_app_name(output) +
+            list(other_spark_opts.keys()) +
+            list(mock_get_mesos_docker_volumes_conf.return_value.keys()) +
+            list(mock_adjust_spark_requested_resources_mesos.return_value.keys()) +
+            list(mock_append_event_log_conf.return_value.keys()) +
+            list(mock_append_sql_shuffle_partitions_conf.return_value.keys()),
+        )
+        assert len(set(output.keys()) - verified_keys) == 0
+        mock_get_mesos_docker_volumes_conf.mocker.assert_called_once_with(
+            mock.ANY, self.extra_volumes, True,
+        )
+        mock_adjust_spark_requested_resources_mesos.mocker.assert_called_once_with(
+            mock.ANY, 'mesos', self.pool,
+        )
+        mock_append_event_log_conf.mocker.assert_called_once_with(
+            mock.ANY, *aws_creds,
+        )
+        mock_append_sql_shuffle_partitions_conf.mocker.assert_called_once_with(
+            mock.ANY,
+        )
+        (warning_msg,), _ = mock_log.warning.call_args
+        assert next(iter(not_allowed_opts.keys())) in warning_msg
+
+    @pytest.fixture
+    def assert_kubernetes_conf(self):
+        expected_output = {
+            'spark.master': f'k8s://https://k8s.paasta-{self.cluster}.yelp:16443',
+            'spark.executorEnv.PAASTA_SERVICE': self.service,
+            'spark.executorEnv.PAASTA_INSTANCE': self.instance,
+            'spark.executorEnv.PAASTA_CLUSTER': self.cluster,
+            'spark.executorEnv.PAASTA_INSTANCE_TYPE': 'spark',
+            'spark.executorEnv.SPARK_EXECUTOR_DIRS': '/tmp',
+            'spark.kubernetes.pyspark.pythonVersion': '3',
+            'spark.kubernetes.container.image': self.docker_image,
+            'spark.kubernetes.namespace': 'paasta-spark',
+            'spark.kubernetes.authenticate.caCertFile': f'{spark_config.K8S_AUTH_FOLDER}/{self.cluster}-ca.crt',
+            'spark.kubernetes.authenticate.clientKeyFile': f'{spark_config.K8S_AUTH_FOLDER}/{self.cluster}-client.key',
+            'spark.kubernetes.authenticate.clientCertFile': (
+                f'{spark_config.K8S_AUTH_FOLDER}/{self.cluster}-client.crt'
+            ),
+            'spark.kubernetes.container.image.pullPolicy': 'Always',
+            'spark.kubernetes.executor.label.yelp.com/paasta_service': self.service,
+            'spark.kubernetes.executor.label.yelp.com/paasta_instance': self.instance,
+            'spark.kubernetes.executor.label.yelp.com/paasta_cluster': self.cluster,
+            'spark.kubernetes.executor.label.paasta.yelp.com/service': self.service,
+            'spark.kubernetes.executor.label.paasta.yelp.com/instance': self.instance,
+            'spark.kubernetes.executor.label.paasta.yelp.com/cluster': self.cluster,
+            'spark.kubernetes.node.selector.yelp.com/pool': self.pool,
+            'spark.kubernetes.executor.label.yelp.com/pool': self.pool,
+        }
+        for i, volume in enumerate(self.extra_volumes):
+            expected_output[f'spark.kubernetes.executor.volumes.hostPath.{i}.mount.path'] = volume['containerPath']
+            expected_output[f'spark.kubernetes.executor.volumes.hostPath.{i}.mount.readOnly'] = str(
+                volume['mode'] == 'RO',
+            ).lower()
+            expected_output[f'spark.kubernetes.executor.volumes.hostPath.{i}.options.path'] = volume['hostPath']
+
+        def verify(output):
+            for key, value in expected_output.items():
+                assert output[key] == value
+            return list(expected_output.keys())
+        return verify
+
+    def tes_leaderst_get_spark_conf_kubernetes(
+        self,
+        user_spark_opts,
+        spark_opts_from_env,
+        ui_port,
+        mock_append_event_log_conf,
+        mock_append_sql_shuffle_partitions_conf,
+        mock_adjust_spark_requested_resources_kubernetes,
+        mock_time,
+        assert_ui_port,
+        assert_app_name,
+        assert_kubernetes_conf,
+        mock_log,
+    ):
+        other_spark_opts = {'spark.driver.memory': '2g', 'spark.executor.memoryOverhead': '1024'}
+        user_spark_opts = {
+            **(user_spark_opts or {}),
+            **other_spark_opts,
+        }
+
+        aws_creds = (None, None, None)
+
+        output = spark_config.get_spark_conf(
+            cluster_manager='kubernetes',
+            spark_app_base_name=self.spark_app_base_name,
+            user_spark_opts=user_spark_opts,
+            paasta_cluster=self.cluster,
+            paasta_pool=self.pool,
+            paasta_service=self.service,
+            paasta_instance=self.instance,
+            docker_img=self.docker_image,
+            extra_volumes=self.extra_volumes,
+            aws_creds=aws_creds,
+            spark_opts_from_env=spark_opts_from_env,
+        )
+
+        verified_keys = set(
+            assert_ui_port(output) +
+            assert_app_name(output) +
+            assert_kubernetes_conf(output) +
+            list(other_spark_opts.keys()) +
+            list(mock_adjust_spark_requested_resources_kubernetes.return_value.keys()) +
+            list(mock_append_event_log_conf.return_value.keys()) +
+            list(mock_append_sql_shuffle_partitions_conf.return_value.keys()),
+        )
+        assert len(set(output.keys()) - verified_keys) == 0
+        mock_adjust_spark_requested_resources_kubernetes.mocker.assert_called_once_with(
+            mock.ANY, 'kubernetes', self.pool,
+        )
+        mock_append_event_log_conf.mocker.assert_called_once_with(
+            mock.ANY, *aws_creds,
+        )
+        mock_append_sql_shuffle_partitions_conf.mocker.assert_called_once_with(
+            mock.ANY,
+        )
+
+    @pytest.mark.parametrize('reason', ['mesos_leader', 'mesos_secret'])
+    def test_get_spark_conf_mesos_error(self, reason, monkeypatch, mock_request_mesos_leader):
+        if reason == 'mesos_leader':
+            mock_request_mesos_leader.side_effect = spark_config.requests.RequestException()
+        else:
+            monkeypatch.setattr(spark_config, 'DEFAULT_SPARK_MESOS_SECRET_FILE', '/not_exist')
+        with pytest.raises(ValueError):
+            spark_config.get_spark_conf(
+                cluster_manager='mesos',
+                spark_app_base_name=self.spark_app_base_name,
+                user_spark_opts={},
+                paasta_cluster=self.cluster,
+                paasta_pool=self.pool,
+                paasta_service=self.service,
+                paasta_instance=self.instance,
+                docker_img=self.docker_image,
+                aws_creds=(None, None, None),
+                extra_volumes=[],
+            )
 
 
-def test_non_config_opts(config_args):
-    config_args['user_spark_opts']['spark.master'] = 'foo'
-    with pytest.raises(ValueError):
-        get_mesos_spark_env(**config_args)
+def test_stringify_spark_env():
+    conf = {'spark.mesos.leader': '1234', 'spark.mesos.principal': 'spark'}
+    assert spark_config.stringify_spark_env(conf) == (
+        '--conf spark.mesos.leader=1234 --conf spark.mesos.principal=spark'
+    )
 
 
-def test_non_config_opts_k8s_volume(config_args):
-    config_args['user_spark_opts']['spark.kubernetes.executor.volumes.hostPath.some_path.mount.path'] = 'foo'
-    with pytest.raises(ValueError):
-        get_mesos_spark_env(**config_args)
+@pytest.mark.parametrize(
+    'spark_conf,expected_output', [
+        ({'spark.eventLog.enabled': 'false'}, None),
+        (
+            {'spark.eventLog.enabled': 'true', 'spark.eventLog.dir': 's3a://test/eventlog'},
+            'https://spark-history-testing',
+        ),
+        (
+            {'spark.eventLog.enabled': 'true', 'spark.eventLog.dir': 's3a://test/different/eventlog'},
+            None,
+        ),
+    ],
+)
+def test_get_history_url(mock_spark_run_conf, spark_conf, expected_output):
+    assert spark_config.get_history_url(spark_conf) == expected_output
 
 
-def test_invalid_cores(config_args):
-    config_args['user_spark_opts']['spark.executor.cores'] = 10
-    with pytest.raises(ValueError):
-        get_mesos_spark_env(**config_args)
+@pytest.mark.parametrize(
+    'memory_string,expected_output', [
+        ('1g', 1024),
+        ('2048', 2048),
+    ],
+)
+def test_parse_memory_string(memory_string, expected_output):
+    assert spark_config.parse_memory_string(memory_string) == expected_output
 
 
-def test_invalid_mem(config_args):
-    config_args['user_spark_opts']['spark.executor.memory'] = '64x'
-    with pytest.raises(ValueError):
-        get_mesos_spark_env(**config_args)
-
-
-@pytest.mark.parametrize('shuffle_partitions', [None, 20])
-@pytest.mark.parametrize('needs_docker_cfg', [True, False])
-def test_get_mesos_spark_env(shuffle_partitions, needs_docker_cfg, config_args):
-    config_args['user_spark_opts']['spark.sql.shuffle.partitions'] = shuffle_partitions
-    config_args['needs_docker_cfg'] = needs_docker_cfg
-    spark_env = get_mesos_spark_env(**config_args)
-    expected = {
-        'spark.app.name': 'my-spark-app',
-        'spark.cores.max': '4',
-        'spark.eventLog.dir': '/var/log',
-        'spark.eventLog.enabled': 'true',
-        'spark.executor.cores': '2',
-        'spark.executor.memory': '4g',
-        'spark.executorEnv.PAASTA_CLUSTER': 'westeros-devc',
-        'spark.executorEnv.PAASTA_INSTANCE': 'batch',
-        'spark.executorEnv.PAASTA_INSTANCE_TYPE': 'spark',
-        'spark.executorEnv.PAASTA_SERVICE': 'spark-service',
-        'spark.executorEnv.SPARK_EXECUTOR_DIRS': '/tmp',
-        'spark.master': 'mesos://the-mesos-leader:5050',
-        'spark.mesos.constraints': 'pool:spark-pool',
-        'spark.mesos.executor.docker.forcePullImage': 'true',
-        'spark.mesos.executor.docker.image': 'docker-dev.nowhere.com/spark:latest',
-        'spark.mesos.executor.docker.parameters': 'cpus=2,label=paasta_service=spark-service,'
-        'label=paasta_instance=batch',
-        'spark.mesos.executor.docker.volumes': '/nail/var:/nail/var:ro,/etc/foo:/etc/foo:ro',
-        'spark.sql.shuffle.partitions': shuffle_partitions or '8',
-        'spark.ui.port': '1234',
+def test_get_signalfx_url():
+    spark_conf = {
+        'spark.executorEnv.PAASTA_CLUSTER': 'test-cluster',
+        'spark.executorEnv.PAASTA_SERVICE': 'test-service',
+        'spark.executorEnv.PAASTA_INSTANCE': 'test-instance',
     }
-    if needs_docker_cfg:
-        expected['spark.mesos.uris'] = 'file:///root/.dockercfg'
-    assert spark_env == expected
+    assert spark_config.get_signalfx_url(spark_conf) == (
+        'https://app.signalfx.com/#/dashboard/DJzYJDkAcAA?density=4'
+        '&variables%5B%5D=Instance%3Dinstance_name:'
+        '&variables%5B%5D=Service%3Dservice_name:%5B%22spark%22%5D'
+        '&variables%5B%5D=PaaSTA%20Cluster%3Dpaasta_cluster:test-cluster'
+        '&variables%5B%5D=PaaSTA%20Service%3Dpaasta_service:test-service'
+        '&variables%5B%5D=PaaSTA%20Instance%3Dpaasta_instance:test-instance'
+        '&startTime=-6h&endTime=Now'
+    )
 
 
-@pytest.mark.parametrize('log_dir,expected', [('/var/log', True), (None, False)])
-def test_get_mesos_spark_env_event_log_dir(config_args, log_dir, expected):
-    config_args['event_log_dir'] = log_dir
-    spark_env = get_mesos_spark_env(**config_args)
-    assert ('spark.eventLog.dir' in spark_env) == expected
+@pytest.mark.parametrize(
+    'spark_opts,expected_output', [
+        # mesos ( 2 instances, not configure memory overhead, default: 384m )
+        (
+            {
+                'spark.cores.max': '10',
+                'spark.executor.cores': '5',
+                'spark.executor.memory': '2g',
+            },
+            {
+                'cpus': 10,
+                'mem': (384 + 2048) * 2,
+                'disk': (384 + 2048) * 2,
+                'gpus': 0,
+            },
+        ),
+        # mesos ( 2 instances, not configure memory overhead, default: 409m )
+        (
+            {
+                'spark.cores.max': '10',
+                'spark.executor.cores': '5',
+                'spark.executor.memory': '4g',
+            },
+            {
+                'cpus': 10,
+                'mem': (409 + 4096) * 2,
+                'disk': (409 + 4096) * 2,
+                'gpus': 0,
+            },
+        ),
+        # mesos ( 2 instances, configure memory overhead)
+        (
+            {
+                'spark.cores.max': '10',
+                'spark.executor.cores': '5',
+                'spark.executor.memory': '4g',
+                'spark.executor.memoryOverhead': '3072',
+            },
+            {
+                'cpus': 10,
+                'mem': (3072 + 4096) * 2,
+                'disk': (3072 + 4096) * 2,
+                'gpus': 0,
+            },
+        ),
+        # k8s
+        (
+            {
+                'spark.executor.instances': '2',
+                'spark.executor.cores': '5',
+                'spark.executor.memory': '4g',
+                'spark.executor.memoryOverhead': '3072',
+            },
+            {
+                'cpus': 10,
+                'mem': (3072 + 4096) * 2,
+                'disk': (3072 + 4096) * 2,
+                'gpus': 0,
+            },
+        ),
+        # gpu
+        (
+            {
+                'spark.cores.max': '10',
+                'spark.mesos.gpus.max': '2',
+                'spark.executor.cores': '5',
+                'spark.executor.memory': '4g',
+                'spark.executor.memoryOverhead': '3072',
+            },
+            {
+                'cpus': 10,
+                'mem': (3072 + 4096) * 2,
+                'disk': (3072 + 4096) * 2,
+                'gpus': 2,
+            },
+
+        ),
+    ],
+)
+def test_get_clusterman_resource_requirements(spark_opts, expected_output):
+    assert spark_config.get_clusterman_resource_requirements(spark_opts) == expected_output
 
 
-def test_get_mesos_spark_env_incorrect_file_mode(config_args):
-    config_args['volumes'] = ['/nail/var:/nail/var:false', '/etc/foo:/etc/foo:false']
-    with pytest.raises(ValueError):
-        get_mesos_spark_env(**config_args)
+@pytest.fixture
+def mock_clusterman_metrics(tmpdir, monkeypatch):
+    fp = tmpdir.join('clusterman.yaml')
+    fp.write(yaml.dump({
+        'clusters': {'test-cluster': {'aws_region': 'test-region'}},
+    }))
+    monkeypatch.setattr(spark_config, 'CLUSTERMAN_YAML_FILE_PATH', str(fp))
+    with mock.patch.object(spark_config, 'clusterman_metrics') as m:
+        yield m
 
 
-def test_get_mesos_spark_auth_env():
-    assert get_mesos_spark_auth_env() == {
-        'SPARK_MESOS_PRINCIPAL': 'spark',
-        'SPARK_MESOS_SECRET': 'SHARED_SECRET(SPARK_MESOS_SECRET)',
+@pytest.fixture
+def mock_get_clusterman_resource_requirements():
+    with mock.patch.object(
+        spark_config,
+        'get_clusterman_resource_requirements',
+        return_value={'cpus': 10, 'mem': 2048},
+    ) as m:
+        yield m
+
+
+def test_send_and_calculate_resources_cost(
+    mock_clusterman_metrics,
+    mock_get_clusterman_resource_requirements,
+    mock_time,
+):
+    mock_clusterman_metrics.generate_key_with_dimensions.side_effect = lambda x, _: x
+    app_name = 'test-app'
+    spark_opts = {
+        'spark.executorEnv.PAASTA_CLUSTER': 'test-cluster',
+        'spark.executorEnv.PAASTA_POOL': 'test-pool',
+        'spark.app.name': app_name,
     }
+    web_url = 'https://spark-monitor-url.com/'
+    cost, resources = spark_config.send_and_calculate_resources_cost(spark_opts, web_url)
 
+    expected_dimension = {'framework_name': app_name, 'webui_url': web_url}
 
-@pytest.mark.parametrize('shuffle_partitions', [None, 20])
-def test_get_k8s_spark_env(shuffle_partitions, k8s_config_args):
-    k8s_config_args['user_spark_opts']['spark.sql.shuffle.partitions'] = shuffle_partitions
-    assert get_k8s_spark_env(**k8s_config_args) == {
-        'spark.master': 'k8s://https://k8s.paasta-westeros-devc.yelp:16443',
-        'spark.ui.port': '1234',
-        'spark.executorEnv.PAASTA_SERVICE': 'spark-service',
-        'spark.executorEnv.PAASTA_INSTANCE': 'batch',
-        'spark.executorEnv.PAASTA_CLUSTER': 'westeros-devc',
-        'spark.executorEnv.PAASTA_INSTANCE_TYPE': 'spark',
-        'spark.executorEnv.SPARK_EXECUTOR_DIRS': '/tmp',
-        'spark.kubernetes.pyspark.pythonVersion': '3',
-        'spark.kubernetes.container.image': 'docker-dev.nowhere.com/spark:latest',
-        'spark.kubernetes.namespace': 'paasta-spark',
-        'spark.kubernetes.authenticate.caCertFile': '/etc/spark_k8s_secrets/westeros-devc-ca.crt',
-        'spark.kubernetes.authenticate.clientKeyFile': '/etc/spark_k8s_secrets/westeros-devc-client.key',
-        'spark.kubernetes.authenticate.clientCertFile': '/etc/spark_k8s_secrets/westeros-devc-client.crt',
-        'spark.kubernetes.container.image.pullPolicy': 'Always',
-        'spark.app.name': 'my-spark-app',
-        'spark.cores.max': '4',
-        'spark.executor.cores': '2',
-        'spark.executor.memory': '4g',
-        'spark.eventLog.enabled': 'true',
-        'spark.sql.shuffle.partitions': shuffle_partitions or '8',
-        'spark.eventLog.dir': '/var/log',
-        'spark.kubernetes.executor.volumes.hostPath.0.mount.path': '/nail/etc/beep',
-        'spark.kubernetes.executor.volumes.hostPath.0.mount.readOnly': 'true',
-        'spark.kubernetes.executor.volumes.hostPath.0.options.path': '/nail/etc/beep',
-        'spark.kubernetes.executor.volumes.hostPath.1.mount.path': '/nail/etc/bop',
-        'spark.kubernetes.executor.volumes.hostPath.1.mount.readOnly': 'false',
-        'spark.kubernetes.executor.volumes.hostPath.1.options.path': '/nail/etc/bop',
-        'spark.kubernetes.executor.label.yelp.com/paasta_instance': 'batch',
-        'spark.kubernetes.executor.label.yelp.com/paasta_service': 'spark-service',
-        'spark.kubernetes.executor.label.yelp.com/paasta_cluster': 'westeros-devc',
-        'spark.kubernetes.executor.label.paasta.yelp.com/service': 'spark-service',
-        'spark.kubernetes.executor.label.paasta.yelp.com/instance': 'batch',
-        'spark.kubernetes.executor.label.paasta.yelp.com/cluster': 'westeros-devc',
-        'spark.kubernetes.node.selector.yelp.com/pool': 'spark-pool',
-        'spark.kubernetes.executor.label.yelp.com/pool': 'spark-pool',
-    }
+    mock_clusterman_metrics.generate_key_with_dimensions.assert_has_calls([
+        mock.call('requested_cpus', expected_dimension),
+        mock.call('requested_mem', expected_dimension),
+    ])
 
+    mock_writer = (
+        mock_clusterman_metrics.ClustermanMetricsBotoClient.return_value
+        .get_writer.return_value.__enter__.return_value
+    )
+    mock_writer.send.assert_has_calls([
+        mock.call(('requested_cpus', int(mock_time), 10)),
+        mock.call(('requested_mem', int(mock_time), 2048)),
+    ])
 
-@pytest.mark.parametrize('log_dir,expected', [('/var/log', True), (None, False)])
-def test_get_k8s_spark_env_event_log_dir(k8s_config_args, log_dir, expected):
-    k8s_config_args['event_log_dir'] = log_dir
-    spark_env = get_k8s_spark_env(**k8s_config_args)
-    assert ('spark.eventLog.dir' in spark_env) == expected
+    mock_clusterman_metrics.util.costs.estimate_cost_per_hour.assert_called_once_with(
+        cluster='test-cluster', pool='test-pool', cpus=10, mem=2048,
+    )

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -940,8 +940,8 @@ def test_get_signalfx_url():
         ),
     ],
 )
-def test_get_clusterman_resource_requirements(spark_opts, expected_output):
-    assert spark_config.get_clusterman_resource_requirements(spark_opts) == expected_output
+def test_get_resources_requested(spark_opts, expected_output):
+    assert spark_config.get_resources_requested(spark_opts) == expected_output
 
 
 @pytest.fixture
@@ -956,10 +956,10 @@ def mock_clusterman_metrics(tmpdir, monkeypatch):
 
 
 @pytest.fixture
-def mock_get_clusterman_resource_requirements():
+def mock_get_resources_requested():
     with mock.patch.object(
         spark_config,
-        'get_clusterman_resource_requirements',
+        'get_resources_requested',
         return_value={'cpus': 10, 'mem': 2048},
     ) as m:
         yield m
@@ -967,19 +967,18 @@ def mock_get_clusterman_resource_requirements():
 
 def test_send_and_calculate_resources_cost(
     mock_clusterman_metrics,
-    mock_get_clusterman_resource_requirements,
+    mock_get_resources_requested,
     mock_time,
 ):
     mock_clusterman_metrics.generate_key_with_dimensions.side_effect = lambda x, _: x
     app_name = 'test-app'
     spark_opts = {
         'spark.executorEnv.PAASTA_CLUSTER': 'test-cluster',
-        'spark.executorEnv.PAASTA_POOL': 'test-pool',
         'spark.app.name': app_name,
     }
     web_url = 'https://spark-monitor-url.com/'
     cost, resources = spark_config.send_and_calculate_resources_cost(
-        mock_clusterman_metrics, spark_opts, web_url,
+        mock_clusterman_metrics, spark_opts, web_url, 'test-pool',
     )
 
     expected_dimension = {'framework_name': app_name, 'webui_url': web_url}

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -951,8 +951,8 @@ def mock_clusterman_metrics(tmpdir, monkeypatch):
         'clusters': {'test-cluster': {'aws_region': 'test-region'}},
     }))
     monkeypatch.setattr(spark_config, 'CLUSTERMAN_YAML_FILE_PATH', str(fp))
-    with mock.patch.object(spark_config, 'clusterman_metrics') as m:
-        yield m
+    mock_clusterman_metrics = mock.MagicMock()
+    yield mock_clusterman_metrics
 
 
 @pytest.fixture
@@ -978,7 +978,9 @@ def test_send_and_calculate_resources_cost(
         'spark.app.name': app_name,
     }
     web_url = 'https://spark-monitor-url.com/'
-    cost, resources = spark_config.send_and_calculate_resources_cost(spark_opts, web_url)
+    cost, resources = spark_config.send_and_calculate_resources_cost(
+        mock_clusterman_metrics, spark_opts, web_url,
+    )
 
     expected_dimension = {'framework_name': app_name, 'webui_url': web_url}
 


### PR DESCRIPTION
This pull request combined both paasta spark-run/paasta.tron_tools/spark_tools.paasta into the same location, so that we only need to modify single location for any spark chagnes. 

The related changes based on this PR: 
- paasta: https://github.com/Yelp/paasta/pull/2930
- spark_tools: https://github.yelpcorp.com/python-packages/spark_tools/pull/13

# Testing
- I've modified the unit test to cover this
- I've also manually verified: 
  - Tested with the modified spark_tools: https://folium.yelpcorp.com/notebook/view/19383
  - Tested with paasta spark-run using https://sourcegraph.yelpcorp.com/packages/spark-on-paasta/-/blob/itest/s3.py, and it run succesfully: http://history.spark.paasta-pnw-devc.yelp/history/aba8bfb3-839f-41c1-9455-f40738e18a5c-8623/environment/
  - Tested with tron tools (mesos): https://fluffy.yelpcorp.com/i/1S4MWt9zj7nmbsWwWWVmsJR3cbW9QB5V.html
  - Tested with tron tools (kubernetes): https://fluffy.yelpcorp.com/i/7tGS7cnWCVK454MnpbBx50vH21Lk0RXl.html