### PR TITLE
Do not respond to the production target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,9 @@ UID:=`id -u`
 GID:=`id -g`
 ITERATION=yelp1
 
-.PHONY: all production test tests coverage clean
+.PHONY: all test tests coverage clean
 
-all: production
-
-production:
-	@true
+all: test
 
 test:
 	tox


### PR DESCRIPTION
This package is failing internal CI checks because it responds to the production target, doing nothing. Makefiles which respond to this target have other responsibilities.