### PR TITLE
Pass session.token When Using TemporaryAWSCredentialsProvider

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -46,6 +46,7 @@ NON_CONFIGURABLE_SPARK_OPTS = {
     'spark.executorEnv.SPARK_EXECUTOR_DIRS',
     'spark.hadoop.fs.s3a.access.key',
     'spark.hadoop.fs.s3a.secret.key',
+    'spark.hadoop.fs.s3a.session.token'
     'spark.kubernetes.pyspark.pythonVersion',
     'spark.kubernetes.container.image',
     'spark.kubernetes.namespace',


### PR DESCRIPTION
Per the [cloudera docs](https://docs.cloudera.com/HDPDocuments/HDP3/HDP-3.1.5/bk_cloud-data-access/content/s3-temp-session.html), we need to pass the `session.token` value when interacting with S3 resources and using the `TemporaryAWSCredentialsProvider`. This seems to be the case when running `paasta spark-run --cmd pyspark --aws-profile dev-security` where `dev-security` is a federated role. We see that the error below indicates that s3 can't identify the Access Key ID, and this is due to the fact that these session require the session token be passed to the provider.

```
py4j.protocol.Py4JJavaError: An error occurred while calling None.org.apache.spark.api.java.JavaSparkContext.
: com.amazonaws.services.s3.model.AmazonS3Exception: Status Code: 403, AWS Service: Amazon S3, AWS Request ID: 50EAA20C08401263, AWS Error Code: InvalidAccessKeyId, AWS Error Message: The AWS Access Key Id you provided does not exist in our records., S3 Extended Request ID: dQj75aHdc3MdiJ28/S63Iqey27zOVzk8d5DjYi7fuV8bajehbNK7IC9fKdUE8N5NP/sjFcbEsk4=
        at com.amazonaws.http.AmazonHttpClient.handleErrorResponse(AmazonHttpClient.java:798)
        at com.amazonaws.http.AmazonHttpClient.executeHelper(AmazonHttpClient.java:421)
        at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:232)
        at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:3528)
        at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:3480)
        at com.amazonaws.services.s3.AmazonS3Client.listObjects(AmazonS3Client.java:604)
        at org.apache.hadoop.fs.s3a.S3AFileSystem.getFileStatus(S3AFileSystem.java:960)
        at org.apache.hadoop.fs.s3a.S3AFileSystem.getFileStatus(S3AFileSystem.java:77)
        at org.apache.spark.scheduler.EventLoggingListener.start(EventLoggingListener.scala:97)
        at org.apache.spark.SparkContext.<init>(SparkContext.scala:523)
        at org.apache.spark.api.java.JavaSparkContext.<init>(JavaSparkContext.scala:58)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:247)
        at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
        at py4j.Gateway.invoke(Gateway.java:238)
        at py4j.commands.ConstructorCommand.invokeConstructor(ConstructorCommand.java:80)
        at py4j.commands.ConstructorCommand.execute(ConstructorCommand.java:69)
        at py4j.GatewayConnection.run(GatewayConnection.java:238)
        at java.lang.Thread.run(Thread.java:748)
```
This should fix part of the problem, with https://github.com/Yelp/paasta/pull/3011 being a related fix.

**Testing**
Also, to validate the behavior of `get_aws_credentials` I tested some debug statements to ensure that the exists tests covered all code paths. If an `--aws-profile` flag is included, we should use the boto3 session variables, that will come from a credentials file.

See https://fluffy.yelpcorp.com/i/lkt1fmGvSW2lXtXvjDW3HDfmkZ2D0rhM.html