### PR TITLE
Automatically Configure TemporaryAWSCredentialsProvider if AWS Session Token Is Included in Session Credentials

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -505,10 +505,11 @@ def get_spark_conf(
     :param paasta_service: the service name of the job
     :param paasta_instance: the instance name of the job
     :param docker_img: the docker image used to launch container for spark executor.
-    :param aws_creds: the aws creds to be used for this spark job.
+    :param aws_creds: the aws creds to be used for this spark job. If a key triplet is passed,
+        we configure a different credentials provider to support this workflow.
     :param extra_volumes: extra files to mount on the spark executors
     :param extra_docker_params: extra docker parameters to launch the spark executor
-        cotnainer. This is only being used when `cluster_manager` is set to `mesos`
+        container. This is only being used when `cluster_manager` is set to `mesos`
     :param with_secret: whether the output spark config should include mesos secrets.
         This is only being used when `cluster_manager` is set to `mesos`
     :param needs_docker_cfg: whether we should add docker.cfg file for accessing
@@ -550,7 +551,6 @@ def get_spark_conf(
     # temporary credentials. More details in SEC-13906.
     if aws_creds[2] is not None:
         spark_conf['spark.hadoop.fs.s3a.aws.credentials.provider'] = AWS_TEMP_CREDENTIALS_PROVIDER
-    print(spark_conf)
 
     spark_conf.update({
         'spark.app.name': app_name,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.5.2',
+    version='2.5.3',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -645,7 +645,7 @@ class TestGetSparkConf:
         aws_creds = ('key', 'secret', 'token')
 
         output = spark_config.get_spark_conf(
-            cluster_manager='mesos',  # get an out of bounds error when something other than mesos/kubenetes is passed
+            cluster_manager='mesos',
             spark_app_base_name=self.spark_app_base_name,
             user_spark_opts=user_spark_opts,
             paasta_cluster=self.cluster,

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -645,7 +645,7 @@ class TestGetSparkConf:
         aws_creds = ('key', 'secret', 'token')
 
         output = spark_config.get_spark_conf(
-            cluster_manager='mesos',
+            cluster_manager='kubernetes',
             spark_app_base_name=self.spark_app_base_name,
             user_spark_opts=user_spark_opts,
             paasta_cluster=self.cluster,
@@ -655,7 +655,6 @@ class TestGetSparkConf:
             docker_img=self.docker_image,
             extra_volumes=self.extra_volumes,
             aws_creds=aws_creds,
-            mesos_leader=self.default_mesos_leader,
         )
         assert self.aws_provider_key in output.keys()
         assert 'org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider' == output[self.aws_provider_key]


### PR DESCRIPTION
https://github.com/Yelp/service_configuration_lib/pull/58 wasn't really the whole picture. When using a session token, a separate credentials provider must be included for hadoop s3a to work. In addition to [setting OS environ AWS values](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html#Authenticating_via_the_AWS_Environment_Variables) in the [in the spark env](https://spark.apache.org/docs/latest/cloud-integration.html#authenticating) we must also declare the [TemporaryAWSCredentialsProvider](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html#Using_Session_Credentials_with_TemporaryAWSCredentialsProvider) so they can be utilized. By default, the SimpleAWSCredentialsProvider is used, which doesn't work with session tokens.

Patched locally on https://github.com/Yelp/paasta/pull/3011/files. Verified that the spark conf flags get set automatically if the creds are passed in with a session token. After this change, the caller does not need to specify `--spark-args "spark.hadoop.fs.s3a.aws.credentials.provider=org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider"` for their spark job to work with temporary credentials. 


**Testing w/ Hadoop 3.0.1**
Verified that we can patch this locally with https://github.com/Yelp/service_configuration_lib/pull/58 and call pyspark with out needing to specify the provider. The spark-conf gets updated with the right provider, and pyspark interactive shell is open.
```
(py36-linux) srojas@dev2-uswest2adevc:~/paasta(u/srojas/SEC-13906-pass-session-token-to-spark-env⚡) » paasta spark-run -C pyspark --image docker-dev.yelpcorp.com/spark-
dev-srojas --aws-profile security --spark-args "spark.eventLog.dir=s3a://yelp-spark-event-logs-dev-us-west-2/srojas/"
/nail/home/srojas/paasta/paasta_tools/utils.py:1556: UserWarning: clog is unavailable
  warnings.warn("clog is unavailable")
{'spark.eventLog.dir': 's3a://yelp-spark-event-logs-dev-us-west-2/srojas/', 'spark.hadoop.fs.s3a.aws.credentials.provider': 'org.apache.hadoop.fs.s3a.TemporaryAWSCredent
ialsProvider'}
spark.sql.shuffle.partitions has been set to 8 to be equal to twice the number of requested cores, but you should consider setting a higher value if necessary. Follow y/
spark for help on partition sizing
instance config
```

**Testing w/ Hadoop 2.7.7**
Verified that we can patch this locally on a fresh checkout of master, not using a custom image, using a IAM user, and call pyspark with out needing to specify the provider. The spark-conf does not get updated and pyspark session opens normally.

```
(py36-linux) srojas@dev2-uswest2adevc:~/paasta(master○) » paasta spark-run -C pyspark --aws-profile dev
/nail/home/srojas/paasta/paasta_tools/utils.py:1554: UserWarning: clog is unavailable
  warnings.warn("clog is unavailable")
Please wait while the image (docker-paasta.yelpcorp.com:443/services-spark:paasta-93a4f21c34ff231ed638313bf953dace8aecb48a) is pulled (times out after 5m)...
paasta-93a4f21c34ff231ed638313bf953dace8aecb48a: Pulling from services-spark
d519e2592276: Already exists
d22d2dfcfa9c: Already exists
....
Status: Downloaded newer image for docker-paasta.yelpcorp.com:443/services-spark:paasta-93a4f21c34ff231ed638313bf953dace8aecb48a
>>>> SPARK CONF <<<<
{}
spark.sql.shuffle.partitions has been set to 8 to be equal to twice the number of requested cores, but you should consider setting a higher value if necessary. Follow y/
spark for help on partition sizing

Spark monitoring URL http://dev2-uswest2adevc.uswest2-devc.yelpcorp.com:43013
....
```

When trying with with a IAM federated role, we get the spark configuration update, and the expected error `Error Message: The AWS Access Key Id you provided does not exist in our records` since hadoop v2.7.7 is not compatible with temporary credentials

```
(py36-linux) srojas@dev2-uswest2adevc:~/paasta(master○) » paasta spark-run -C pyspark --aws-profile security
/nail/home/srojas/paasta/paasta_tools/utils.py:1554: UserWarning: clog is unavailable
  warnings.warn("clog is unavailable")
Please wait while the image (docker-paasta.yelpcorp.com:443/services-spark:paasta-93a4f21c34ff231ed638313bf953dace8aecb48a) is pulled (times out after 5m)...
paasta-93a4f21c34ff231ed638313bf953dace8aecb48a: Pulling from services-spark
Digest: sha256:7da6512b1ade1967b747e995efe0691c49d5775b65ed148385bac9266549579e
Status: Image is up to date for docker-paasta.yelpcorp.com:443/services-spark:paasta-93a4f21c34ff231ed638313bf953dace8aecb48a
>>>> SPARK CONF <<<<
{'spark.hadoop.fs.s3a.aws.credentials.provider': 'org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider'}
spark.sql.shuffle.partitions has been set to 8 to be equal to twice the number of requested cores, but you should consider setting a higher value if necessary. Follow y/spark for help on partition sizing
...
py4j.protocol.Py4JJavaError: An error occurred while calling None.org.apache.spark.api.java.JavaSparkContext.
: com.amazonaws.services.s3.model.AmazonS3Exception: Status Code: 403, AWS Service: Amazon S3, AWS Request ID: B0A8C9C1A731AD5C, AWS Error Code: InvalidAccessKeyId, AWS Erro
r Message: The AWS Access Key Id you provided does not exist in our records., S3 Extended Request ID: J6MHyqY+h90o+uyHrl9v6Zif/z9QL8EBFsY3FPbkoSDpA/vyEQzMjHgyMFE2ex1HWUXxBYk
sT9k=
        at com.amazonaws.http.AmazonHttpClient.handleErrorResponse(AmazonHttpClient.java:798)
        at com.amazonaws.http.AmazonHttpClient.executeHelper(AmazonHttpClient.java:421)
        at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:232)
        at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:3528)
        at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:3480)
        at com.amazonaws.services.s3.AmazonS3Client.listObjects(AmazonS3Client.java:604)
        at org.apache.hadoop.fs.s3a.S3AFileSystem.getFileStatus(S3AFileSystem.java:960)
        at org.apache.hadoop.fs.s3a.S3AFileSystem.getFileStatus(S3AFileSystem.java:77)
        at org.apache.spark.scheduler.EventLoggingListener.start(EventLoggingListener.scala:97)
        at org.apache.spark.SparkContext.<init>(SparkContext.scala:523)
        at org.apache.spark.api.java.JavaSparkContext.<init>(JavaSparkContext.scala:58)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
        at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:247)
        at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
        at py4j.Gateway.invoke(Gateway.java:238)
        at py4j.commands.ConstructorCommand.invokeConstructor(ConstructorCommand.java:80)
        at py4j.commands.ConstructorCommand.execute(ConstructorCommand.java:69)
        at py4j.GatewayConnection.run(GatewayConnection.java:238)
        at java.lang.Thread.run(Thread.java:748)
```