### PR TITLE
Bump to Version 2.5.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.5.3',
+    version='2.5.4',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',


### PR DESCRIPTION
Follows up on https://github.com/Yelp/service_configuration_lib/pull/60, which I accidentally pushed the wrong version tag before pulling from latest on master.