### PR TITLE
use spark.mesos.executor.memoryOverhead for memory calculation as well

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -643,11 +643,14 @@ def get_resources_requested(spark_opts: Mapping[str, str]) -> Mapping[str, int]:
     num_gpus = int(spark_opts.get('spark.mesos.gpus.max', 0))
 
     executor_memory = parse_memory_string(spark_opts.get('spark.executor.memory', ''))
+    requested_memory = spark_opts.get(
+        'spark.executor.memoryOverhead',
+    ) or spark_opts.get('spark.mesos.executor.memoryOverhead')
     # by default, spark adds an overhead of 10% of the executor memory, with a
     # minimum of 384mb
     memory_overhead: int = (
-        parse_memory_string(spark_opts['spark.executor.memoryOverhead'])
-        if spark_opts.get('spark.executor.memoryOverhead')
+        parse_memory_string(requested_memory)
+        if requested_memory
         else max(384, int(0.1 * executor_memory))
     )
     total_memory = (executor_memory + memory_overhead) * num_executors

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.5.3',
+    version='2.5.4',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -954,6 +954,37 @@ def test_get_signalfx_url():
                 'gpus': 0,
             },
         ),
+        # mesos ( 2 instances, Duplicate config, choose the higher memory overhead)
+        (
+            {
+                'spark.cores.max': '10',
+                'spark.executor.cores': '5',
+                'spark.executor.memory': '4g',
+                'spark.executor.memoryOverhead': '3072',
+                'spark.mesos.executor.memoryOverhead': '4096',
+            },
+            {
+                'cpus': 10,
+                'mem': (4096 + 4096) * 2,
+                'disk': (4096 + 4096) * 2,
+                'gpus': 0,
+            },
+        ),
+        # mesos ( 2 instances, configure memory overhead)
+        (
+            {
+                'spark.cores.max': '10',
+                'spark.executor.cores': '5',
+                'spark.executor.memory': '4g',
+                'spark.mesos.executor.memoryOverhead': '3072',
+            },
+            {
+                'cpus': 10,
+                'mem': (3072 + 4096) * 2,
+                'disk': (3072 + 4096) * 2,
+                'gpus': 0,
+            },
+        ),
         # k8s
         (
             {
@@ -966,6 +997,21 @@ def test_get_signalfx_url():
                 'cpus': 10,
                 'mem': (3072 + 4096) * 2,
                 'disk': (3072 + 4096) * 2,
+                'gpus': 0,
+            },
+        ),
+        # k8s
+        (
+            {
+                'spark.executor.instances': '2',
+                'spark.executor.cores': '5',
+                'spark.executor.memory': '4g',
+                'spark.kubernetes.memoryOverheadFactor': '0.5',
+            },
+            {
+                'cpus': 10,
+                'mem': (4096 * 0.5 + 4096) * 2,
+                'disk': (4096 * 0.5 + 4096) * 2,
                 'gpus': 0,
             },
         ),


### PR DESCRIPTION
I noticed that `spark.mesos.executor.memoryOverhead` was not being considered when calculating the memory requirements. This might be the possible cause of our issues

## testing done

make test green  