### PR TITLE
Include 'autotuned_defaults' in the list of folders to watch

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@ mock
 mypy
 pre-commit==1.21.0
 pytest
+types-PyYAML
+types-requests

--- a/service_configuration_lib/cached_view.py
+++ b/service_configuration_lib/cached_view.py
@@ -149,6 +149,9 @@ class ConfigsFileWatcher:
         Attempting to watch tmp directories causes pyinotify to log an error,
         so let's just filter them out.
         Also it will exclude all folders which don't match with services_names param.
+
+        'autotuned_defaults' folders will be included so that their values can be used
+        for configuring service timeouts.
         """
         folder_name = Path(path).name
 
@@ -157,6 +160,11 @@ class ConfigsFileWatcher:
                 return True
 
         for service_name in self._services_names:
+            if folder_name == 'autotuned_defaults':
+                service = Path(path).parent.name
+                if fnmatch.fnmatch(service, service_name):
+                    return False
+
             if fnmatch.fnmatch(folder_name, service_name):
                 return False
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.5.4',
+    version='2.5.5',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/cached_view_test.py
+++ b/tests/cached_view_test.py
@@ -52,6 +52,7 @@ def test_exclude_filter_service_names_filtering(configs_file_watcher):
     assert configs_file_watcher._exclude_filter('/foo/another_service2')
     assert not configs_file_watcher._exclude_filter('/foo/star_service2')
     assert not configs_file_watcher._exclude_filter('/foo/star_service')
+    assert not configs_file_watcher._exclude_filter('/foo/star_services/autotuned_defaults')
 
 
 def test_stopping_notifier(configs_file_watcher):


### PR DESCRIPTION
Right now any folders that don't match the `services_names` param are automatically excluded from being watched. This PR updates the filter so that the `autotuned_defaults` folder within folders that match the `services_names` param are also watched, so that the configs within `autotuned_defaults` can be used.