### PR TITLE
Change url for k8s cluster to be used for spark master

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -409,7 +409,7 @@ def _get_k8s_spark_env(
     paasta_pool: str,
 ) -> Dict[str, str]:
     spark_env = {
-        'spark.master': f'k8s://https://k8s.paasta-{paasta_cluster}.yelp:16443',
+        'spark.master': f'k8s://https://k8s.{paasta_cluster}.paasta:6443',
         'spark.executorEnv.PAASTA_SERVICE': paasta_service,
         'spark.executorEnv.PAASTA_INSTANCE': paasta_instance,
         'spark.executorEnv.PAASTA_CLUSTER': paasta_cluster,


### PR DESCRIPTION
Kubernetes cluster URL port seem to have been changed from 16443 to 6443.
As part of PAASTA-17390, the url format needs to be changed.

Testing:
make test

This should be a no-op in production as there is no production branch running spark on k8s job. 
Safe to rollout. 
Testing for same format for infrastage cluster has been done as part of COREML-2459