### PR TITLE
[COREML-2570] fix k8s volumes being mounted twice

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1,4 +1,5 @@
 import hashlib
+import itertools
 import json
 import logging
 import os
@@ -63,11 +64,6 @@ NON_CONFIGURABLE_SPARK_OPTS = {
     'spark.kubernetes.executor.label.paasta.yelp.com/cluster',
 }
 K8S_AUTH_FOLDER = '/etc/pki/spark'
-DEFAULT_SPARK_K8S_SECRET_VOLUME = {
-    'hostPath': K8S_AUTH_FOLDER,
-    'containerPath': K8S_AUTH_FOLDER,
-    'mode': 'RO',
-}
 
 log = logging.Logger(__name__)
 
@@ -172,17 +168,34 @@ def _get_mesos_docker_volumes_conf(
 def _get_k8s_docker_volumes_conf(
     volumes: Optional[List[Mapping[str, str]]] = None,
 ):
+
+    def _get_k8s_volume(host_path, container_path, mode, count=itertools.count()):
+        volume_name = next(count)
+        return {
+            f'spark.kubernetes.executor.volumes.hostPath.{volume_name}.mount.path': container_path,
+            f'spark.kubernetes.executor.volumes.hostPath.{volume_name}.options.path': host_path,
+            f'spark.kubernetes.executor.volumes.hostPath.{volume_name}.mount.readOnly': (
+                'true' if mode.lower() == 'ro' else 'false'
+            ),
+        }
+
     env = {}
+    mounted_volumes = set()
     k8s_volumes = volumes or []
-    k8s_volumes.append(DEFAULT_SPARK_K8S_SECRET_VOLUME)
+    k8s_volumes.append({'containerPath': K8S_AUTH_FOLDER, 'hostPath': K8S_AUTH_FOLDER, 'mode': 'RO'})
     k8s_volumes.append({'containerPath': '/etc/passwd', 'hostPath': '/etc/passwd', 'mode': 'RO'})
     k8s_volumes.append({'containerPath': '/etc/group', 'hostPath': '/etc/group', 'mode': 'RO'})
-    for volume_name, volume in enumerate(k8s_volumes):
-        env[f'spark.kubernetes.executor.volumes.hostPath.{volume_name}.mount.path'] = volume['containerPath']
-        env[f'spark.kubernetes.executor.volumes.hostPath.{volume_name}.mount.readOnly'] = (
-            'true' if volume['mode'].lower() == 'ro' else 'false'
-        )
-        env[f'spark.kubernetes.executor.volumes.hostPath.{volume_name}.options.path'] = volume['hostPath']
+
+    for volume in k8s_volumes:
+        host_path, container_path, mode = volume['hostPath'], volume['containerPath'], volume['mode']
+        if os.path.exists(host_path) and host_path not in mounted_volumes:
+            env.update(_get_k8s_volume(host_path, container_path, mode))
+            mounted_volumes.add(host_path)
+        else:
+            log.warning(
+                f'Path {host_path} does not exist on this host or it has already been mounted.'
+                ' Skipping this bindings.',
+            )
     return env
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.5.7',
+    version='2.5.8',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',


### PR DESCRIPTION
## What changed
Avoid getting spark-run stuck on attempting to mount the same volume twice. Add tests.

## Testing
Build paasta venv with updated library from local path.
```
./paasta_tools/cli/cli.py spark-run --cluster-manager kubernetes -s spark --cmd 'spark-submit /work/integration_tests/s3.py'
```
Output: https://fluffy.yelpcorp.com/i/MqQ4kTV56z1dV80wCGMpKMC7BCdjX0gG.html