### PR TITLE
Creating TypeDict for ServiceInfo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 importlib-resources==1.5.0
 pyinotify==0.9.6
 pyyaml >= 3.0
+mypy-extensions==0.4.1

--- a/service_configuration_lib/__init__.py
+++ b/service_configuration_lib/__init__.py
@@ -22,6 +22,8 @@ import os
 import socket
 import sys
 from typing import Mapping
+from mypy_extensions import TypedDict
+from typing import Dict
 
 import ephemeral_port_reserve
 import yaml
@@ -35,6 +37,19 @@ DEFAULT_SOA_DIR = '/nail/etc/services'
 log = logging.getLogger(__name__)
 _yaml_cache: Mapping[str, Mapping] = {}
 _use_yaml_cache = True
+
+
+class ServiceInfoDict(TypedDict, total=False):
+    port: int
+    monitoring: Dict
+    deploy: Dict
+    data: Dict
+    smartstack: Dict
+    dependencies: Dict
+    description: str
+    external_link: str
+    encryption_key: str
+    git_url: str
 
 
 def enable_yaml_cache():
@@ -115,7 +130,7 @@ def read_yaml_file(file_name, deepcopy=True):
 def generate_service_info(service_information, **kwargs):
     service_info = kwargs
     service_info.update(service_information)
-    return service_info
+    return ServiceInfoDict(service_info)
 
 
 def read_extra_service_information(service_name, extra_info, soa_dir=DEFAULT_SOA_DIR, deepcopy=True):

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'pyinotify',
         'requests>=2.18.4',
         'boto3',
+        'mypy-extensions'
     ],
     license='Copyright Yelp 2013, All Rights Reserved',
     scripts=[


### PR DESCRIPTION
This PR creates a TypeDict for `service_configuration_lib.read_service_configuration_from_dir()` to make more clear how magically `smartstack`/`port`/`monitoring`/`deploy`/`data`/`dependencies`, etc. are loaded in `InstanceConfigDict`