### PR TITLE
[COREML-2694] automatically compute and set k8s executor limit cores and batch size

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -36,6 +36,7 @@ DEFAULT_EXECUTOR_CORES = 2
 DEFAULT_EXECUTOR_INSTANCES = 2
 DEFAULT_EXECUTOR_MEMORY = '4g'
 DEFAULT_K8S_LABEL_LENGTH = 63
+DEFAULT_K8S_BATCH_SIZE = 512
 
 
 NON_CONFIGURABLE_SPARK_OPTS = {
@@ -286,6 +287,11 @@ def _adjust_spark_requested_resources(
             user_spark_opts.setdefault('spark.executor.instances', str(DEFAULT_EXECUTOR_INSTANCES)),
         )
         max_cores = executor_instances * executor_cores
+        user_spark_opts.setdefault(
+            'spark.kubernetes.allocation.batch.size',
+            str(min(executor_instances, DEFAULT_K8S_BATCH_SIZE)),
+        )
+        user_spark_opts.setdefault('spark.kubernetes.executor.limit.cores', str(executor_cores))
 
     if max_cores < executor_cores:
         raise ValueError(f'Total number of cores {max_cores} is less than per-executor cores {executor_cores}')

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -300,7 +300,28 @@ class TestGetSparkConf:
             (
                 'kubernetes',
                 {},
-                {'spark.executor.memory': '4g', 'spark.executor.cores': '2', 'spark.executor.instances': '2'},
+                {
+                    'spark.executor.memory': '4g',
+                    'spark.executor.cores': '2',
+                    'spark.executor.instances': '2',
+                    'spark.kubernetes.executor.limit.cores': '2',
+                    'spark.kubernetes.allocation.batch.size': '2',
+                },
+            ),
+            # user defined resources with k8s
+            (
+                'kubernetes',
+                {
+                    'spark.executor.cores': '2',
+                    'spark.executor.instances': '600',
+                },
+                {
+                    'spark.executor.memory': '4g',
+                    'spark.executor.cores': '2',
+                    'spark.executor.instances': '600',
+                    'spark.kubernetes.executor.limit.cores': '2',
+                    'spark.kubernetes.allocation.batch.size': '512',
+                },
             ),
             # use default mesos settings
             (
@@ -372,8 +393,8 @@ class TestGetSparkConf:
         output = spark_config._adjust_spark_requested_resources(
             user_spark_opts, cluster_manager, pool,
         )
-        for key in expected_output:
-            assert output[key] == expected_output[key]
+        for key in expected_output.keys():
+            assert output[key] == expected_output[key], f'wrong value for {key}'
 
     @pytest.mark.parametrize(
         'cluster_manager,spark_opts,pool', [


### PR DESCRIPTION
## Context

We want to automatically set `spark.kubernetes.allocation.batch.size` and  `spark.kubernetes.executor.limit.cores`. The former will help scaling up clusters for accommodating the executors, the latter will prevent certain Spark jobs to starve each others cpu pool.

## Testing
`make test` updated and passing.