### PR TITLE
[COREML-2800] set default spark.scheduler.maxRegisteredResourcesWaitingTime for kubernetes batches

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -38,6 +38,7 @@ DEFAULT_EXECUTOR_MEMORY = '4g'
 DEFAULT_K8S_LABEL_LENGTH = 63
 DEFAULT_K8S_BATCH_SIZE = 512
 DEFAULT_RESOURCES_WAITING_TIME_PER_EXECUTOR = 2  # seconds
+DEFAULT_CLUSTERMAN_OBSERVED_SCALING_TIME = 15  # minutes
 
 
 NON_CONFIGURABLE_SPARK_OPTS = {
@@ -293,9 +294,13 @@ def _adjust_spark_requested_resources(
             str(min(executor_instances, DEFAULT_K8S_BATCH_SIZE)),
         )
         user_spark_opts.setdefault('spark.kubernetes.executor.limit.cores', str(executor_cores))
+        waiting_time = (
+            DEFAULT_CLUSTERMAN_OBSERVED_SCALING_TIME +
+            executor_instances * DEFAULT_RESOURCES_WAITING_TIME_PER_EXECUTOR // 60
+        )
         user_spark_opts.setdefault(
             'spark.scheduler.maxRegisteredResourcesWaitingTime',
-            str(10 + executor_instances * DEFAULT_RESOURCES_WAITING_TIME_PER_EXECUTOR // 60) + 'min',
+            str(waiting_time) + 'min',
         )
 
     if max_cores < executor_cores:

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -37,6 +37,7 @@ DEFAULT_EXECUTOR_INSTANCES = 2
 DEFAULT_EXECUTOR_MEMORY = '4g'
 DEFAULT_K8S_LABEL_LENGTH = 63
 DEFAULT_K8S_BATCH_SIZE = 512
+DEFAULT_RESOURCES_WAITING_TIME_PER_EXECUTOR = 2  # seconds
 
 
 NON_CONFIGURABLE_SPARK_OPTS = {
@@ -292,6 +293,10 @@ def _adjust_spark_requested_resources(
             str(min(executor_instances, DEFAULT_K8S_BATCH_SIZE)),
         )
         user_spark_opts.setdefault('spark.kubernetes.executor.limit.cores', str(executor_cores))
+        user_spark_opts.setdefault(
+            'spark.scheduler.maxRegisteredResourcesWaitingTime',
+            str(10 + executor_instances * DEFAULT_RESOURCES_WAITING_TIME_PER_EXECUTOR // 60) + 'min',
+        )
 
     if max_cores < executor_cores:
         raise ValueError(f'Total number of cores {max_cores} is less than per-executor cores {executor_cores}')

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.7.0',
+    version='2.8.0',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -306,6 +306,7 @@ class TestGetSparkConf:
                     'spark.executor.instances': '2',
                     'spark.kubernetes.executor.limit.cores': '2',
                     'spark.kubernetes.allocation.batch.size': '2',
+                    'spark.scheduler.maxRegisteredResourcesWaitingTime': '10min',
                 },
             ),
             # user defined resources with k8s
@@ -321,6 +322,7 @@ class TestGetSparkConf:
                     'spark.executor.instances': '600',
                     'spark.kubernetes.executor.limit.cores': '2',
                     'spark.kubernetes.allocation.batch.size': '512',
+                    'spark.scheduler.maxRegisteredResourcesWaitingTime': '30min',
                 },
             ),
             # use default mesos settings

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -306,7 +306,7 @@ class TestGetSparkConf:
                     'spark.executor.instances': '2',
                     'spark.kubernetes.executor.limit.cores': '2',
                     'spark.kubernetes.allocation.batch.size': '2',
-                    'spark.scheduler.maxRegisteredResourcesWaitingTime': '10min',
+                    'spark.scheduler.maxRegisteredResourcesWaitingTime': '15min',
                 },
             ),
             # user defined resources with k8s
@@ -322,7 +322,7 @@ class TestGetSparkConf:
                     'spark.executor.instances': '600',
                     'spark.kubernetes.executor.limit.cores': '2',
                     'spark.kubernetes.allocation.batch.size': '512',
-                    'spark.scheduler.maxRegisteredResourcesWaitingTime': '30min',
+                    'spark.scheduler.maxRegisteredResourcesWaitingTime': '35min',
                 },
             ),
             # use default mesos settings


### PR DESCRIPTION
Ticket: [COREML-2800](https://jira.yelpcorp.com/browse/COREML-2800)
As per ticket, we're going to set the default max time as 10min (instead of 15min, it's been working well for some batches I've been testing) plus 2 seconds for each executor that need to be instantiated. I also updated testing accordingly.

## Testing

`make test`: updated and passes ✅ 
Manual test:
```
 ▲ py37-linux ~pg/paasta pip install ../service_configuration_lib
 △ py37-linux ~pg/paasta ./paasta_tools/cli/cli.py spark-run --cluster pnw-devc --service ad_bidding_transform --pool stable_batch --cluster-manager kubernetes --cmd 'spark-submit /code/virtualenv_run/bin/spark_etl_runner.py --feature-config /code/batch/campaign_info_daily/job_configs/ad_shutoff_and_traffic_integration.yaml --env-config-path /nail/srv/configs/ad_bidding_transform.yaml --team-name ad_market_dynamics --no-notification --start-date 2021-09-16 --end-date 2021-09-16 --publish-path s3a://yelp-emr-dev-us-west-2/gcoll/k8s_darklaunch/ ' --spark-args ' spark.executor.instances=8 spark.executor.memory=16g spark.executor.cores=4 spark.driver.memory=8g spark.driver.cores=5'
```
![image](https://user-images.githubusercontent.com/787586/148277405-4720f53c-4687-4aa8-93c2-d31e1ba9a584.png)
