### PR TITLE
Add func to read soa-configs metadata file

### DIFF
--- a/service_configuration_lib/__init__.py
+++ b/service_configuration_lib/__init__.py
@@ -176,6 +176,11 @@ def list_services(soa_dir=DEFAULT_SOA_DIR):
     return os.listdir(rootdir)
 
 
+def read_soa_metadata(soa_dir=DEFAULT_SOA_DIR):
+    """Reads the metadata file in the SOA directory"""
+    return read_yaml_file(os.path.join(os.path.abspath(soa_dir), '.metadata.json'))
+
+
 def get_service_from_port(port, all_services=None):
     """Gets the name of the service from the port
     all_services allows you to feed in the services to look through, pass

--- a/tests/service_configuration_lib_test.py
+++ b/tests/service_configuration_lib_test.py
@@ -214,6 +214,18 @@ class TestServiceConfigurationLib:
         listdir_patch.assert_called_once_with('nodir')
         assert expected == actual
 
+    def test_read_soa_metadata(self, tmpdir):
+        soa_dir = tmpdir.mkdir('test_read_soa_metadata')
+        metadata_file = soa_dir.join('.metadata.json')
+        metadata_file.write('{"hello":"world"}')
+        actual_metadata = service_configuration_lib.read_soa_metadata(soa_dir=str(soa_dir))
+        assert actual_metadata == {'hello': 'world'}
+
+    def test_read_soa_metadata_dne(self, tmpdir):
+        soa_dir = tmpdir.mkdir('test_read_soa_metadata_dne')
+        actual_metadata = service_configuration_lib.read_soa_metadata(soa_dir=str(soa_dir))
+        assert actual_metadata == {}
+
     @mock.patch('service_configuration_lib.read_service_configuration_from_dir', return_value='bye')
     @mock.patch('os.path.abspath', return_value='cafe')
     def test_read_service_configuration(self, abs_patch, read_patch):


### PR DESCRIPTION
### Description
This PR adds a simple function to read the new soa-configs metadata file. If it doesn't exist, an empty dict is returned.

### Testing
`make test`