### PR TITLE
COREML-3095 | Prevent auto calculation of executor instances and accurate num_partitions with DRA

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -297,7 +297,10 @@ def _adjust_spark_requested_resources(
     elif cluster_manager == 'kubernetes':
         # TODO(gcoll|COREML-2697): Consider cleaning this part of the code up
         # once mesos is not longer around at Yelp.
-        if 'spark.executor.instances' not in user_spark_opts:
+        if (
+                'spark.executor.instances' not in user_spark_opts and
+                ('spark.dynamicAllocation.enabled' not in user_spark_opts or str(user_spark_opts['spark.dynamicAllocation.enabled']) != 'true')
+        ):
             executor_instances = int(user_spark_opts.get('spark.cores.max', str(DEFAULT_MAX_CORES))) // executor_cores
             user_spark_opts['spark.executor.instances'] = str(executor_instances)
         if (

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -300,7 +300,8 @@ def _adjust_spark_requested_resources(
         # once mesos is not longer around at Yelp.
         if (
                 'spark.executor.instances' not in user_spark_opts and
-                ('spark.dynamicAllocation.enabled' not in user_spark_opts or str(user_spark_opts['spark.dynamicAllocation.enabled']) != 'true')
+                ('spark.dynamicAllocation.enabled' not in user_spark_opts or
+                 str(user_spark_opts['spark.dynamicAllocation.enabled']) != 'true')
         ):
             executor_instances = int(user_spark_opts.get('spark.cores.max', str(DEFAULT_MAX_CORES))) // executor_cores
             user_spark_opts['spark.executor.instances'] = str(executor_instances)

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -300,8 +300,10 @@ def _adjust_spark_requested_resources(
         # once mesos is not longer around at Yelp.
         if (
                 'spark.executor.instances' not in user_spark_opts and
-                ('spark.dynamicAllocation.enabled' not in user_spark_opts or
-                 str(user_spark_opts['spark.dynamicAllocation.enabled']) != 'true')
+                (
+                    'spark.dynamicAllocation.enabled' not in user_spark_opts or
+                    str(user_spark_opts['spark.dynamicAllocation.enabled']) != 'true'
+                )
         ):
             executor_instances = int(user_spark_opts.get('spark.cores.max', str(DEFAULT_MAX_CORES))) // executor_cores
             user_spark_opts['spark.executor.instances'] = str(executor_instances)

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -221,9 +221,9 @@ def _append_sql_shuffle_partitions_conf(spark_opts: Dict[str, str]) -> Dict[str,
         return spark_opts
 
     num_partitions = 2 * (
-        int(spark_opts.get('spark.cores.max', 0)) or
-        int(spark_opts.get('spark.executor.instances', 0)) * int(spark_opts.get('spark.executor.cores', 0)) or
         int(spark_opts.get('spark.dynamicAllocation.maxExecutors', 0)) * int(spark_opts.get('spark.executor.cores', 0))
+        or int(spark_opts.get('spark.cores.max', 0))
+        or int(spark_opts.get('spark.executor.instances', 0)) * int(spark_opts.get('spark.executor.cores', 0))
     )
     log.warning(
         f'spark.sql.shuffle.partitions has been set to {num_partitions} '

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -222,7 +222,8 @@ def _append_sql_shuffle_partitions_conf(spark_opts: Dict[str, str]) -> Dict[str,
 
     num_partitions = 2 * (
         int(spark_opts.get('spark.cores.max', 0)) or
-        int(spark_opts.get('spark.executor.instances', 0)) * int(spark_opts.get('spark.executor.cores', 0))
+        int(spark_opts.get('spark.executor.instances', 0)) * int(spark_opts.get('spark.executor.cores', 0)) or
+        int(spark_opts.get('spark.dynamicAllocation.maxExecutors', 0)) * int(spark_opts.get('spark.executor.cores', 0))
     )
     log.warning(
         f'spark.sql.shuffle.partitions has been set to {num_partitions} '

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -223,7 +223,8 @@ def _append_sql_shuffle_partitions_conf(spark_opts: Dict[str, str]) -> Dict[str,
 
     num_partitions = 2 * (
         int(spark_opts.get('spark.cores.max', 0)) or
-        int(spark_opts.get('spark.executor.instances', 0)) * int(spark_opts.get('spark.executor.cores', 0))
+        int(spark_opts.get('spark.executor.instances', 0)) *
+        int(spark_opts.get('spark.executor.cores', DEFAULT_EXECUTOR_CORES))
     )
 
     if (
@@ -235,7 +236,7 @@ def _append_sql_shuffle_partitions_conf(spark_opts: Dict[str, str]) -> Dict[str,
 
         num_partitions_dra = 2 * (
             int(spark_opts.get('spark.dynamicAllocation.maxExecutors', 0)) *
-            int(spark_opts.get('spark.executor.cores', 0))
+            int(spark_opts.get('spark.executor.cores', DEFAULT_EXECUTOR_CORES))
         )
         num_partitions = max(num_partitions, num_partitions_dra)
 
@@ -326,12 +327,12 @@ def _adjust_spark_requested_resources(
                     str(DEFAULT_MAX_CORES),
                 )) // executor_cores
                 user_spark_opts['spark.executor.instances'] = str(executor_instances)
-        else:
-            if (
-                    'spark.dynamicAllocation.enabled' in user_spark_opts and
-                    str(user_spark_opts['spark.dynamicAllocation.enabled']) == 'true'
-            ):
-                user_spark_opts['spark.executor.instances'] = str(DEFAULT_EXECUTOR_INSTANCES)
+
+        elif (
+            'spark.dynamicAllocation.enabled' in user_spark_opts and
+            str(user_spark_opts['spark.dynamicAllocation.enabled']) == 'true'
+        ):
+            user_spark_opts['spark.executor.instances'] = str(DEFAULT_EXECUTOR_INSTANCES)
 
         if (
             'spark.mesos.executor.memoryOverhead' in user_spark_opts and

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -39,6 +39,7 @@ DEFAULT_K8S_LABEL_LENGTH = 63
 DEFAULT_K8S_BATCH_SIZE = 512
 DEFAULT_RESOURCES_WAITING_TIME_PER_EXECUTOR = 2  # seconds
 DEFAULT_CLUSTERMAN_OBSERVED_SCALING_TIME = 15  # minutes
+DEFAULT_SQL_SHUFFLE_PARTITIONS = 128
 
 
 NON_CONFIGURABLE_SPARK_OPTS = {
@@ -221,17 +222,27 @@ def _append_sql_shuffle_partitions_conf(spark_opts: Dict[str, str]) -> Dict[str,
         return spark_opts
 
     num_partitions = 2 * (
-        int(spark_opts.get('spark.dynamicAllocation.maxExecutors', 0)) *
-        int(spark_opts.get('spark.executor.cores', 0)) or
         int(spark_opts.get('spark.cores.max', 0)) or
         int(spark_opts.get('spark.executor.instances', 0)) * int(spark_opts.get('spark.executor.cores', 0))
     )
+
+    if ('spark.dynamicAllocation.enabled' in user_spark_opts and
+            str(user_spark_opts['spark.dynamicAllocation.enabled']) == 'true' and
+            'spark.dynamicAllocation.maxExecutors' in user_spark_opts and
+            str(user_spark_opts['spark.dynamicAllocation.maxExecutors']) != 'infinity'):
+        num_partitions_dra = (int(spark_opts.get('spark.dynamicAllocation.maxExecutors', 0)) *
+                              int(spark_opts.get('spark.executor.cores', 0)))
+        num_partitions = max(num_partitions, num_partitions_dra)
+
+    num_partitions = num_partitions or DEFAULT_SQL_SHUFFLE_PARTITIONS
+
     log.warning(
         f'spark.sql.shuffle.partitions has been set to {num_partitions} '
         'to be equal to twice the number of requested cores, but you should '
         'consider setting a higher value if necessary.'
         ' Follow y/spark for help on partition sizing',
     )
+
     spark_opts['spark.sql.shuffle.partitions'] = str(num_partitions)
     return spark_opts
 
@@ -299,15 +310,21 @@ def _adjust_spark_requested_resources(
     elif cluster_manager == 'kubernetes':
         # TODO(gcoll|COREML-2697): Consider cleaning this part of the code up
         # once mesos is not longer around at Yelp.
-        if (
-                'spark.executor.instances' not in user_spark_opts and
-                (
+        if 'spark.executor.instances' not in user_spark_opts:
+
+            if (
                     'spark.dynamicAllocation.enabled' not in user_spark_opts or
                     str(user_spark_opts['spark.dynamicAllocation.enabled']) != 'true'
-                )
-        ):
-            executor_instances = int(user_spark_opts.get('spark.cores.max', str(DEFAULT_MAX_CORES))) // executor_cores
-            user_spark_opts['spark.executor.instances'] = str(executor_instances)
+            ):
+                executor_instances = int(user_spark_opts.get('spark.cores.max', str(DEFAULT_MAX_CORES))) // executor_cores
+                user_spark_opts['spark.executor.instances'] = str(executor_instances)
+        else:
+            if (
+                    'spark.dynamicAllocation.enabled' in user_spark_opts and
+                    str(user_spark_opts['spark.dynamicAllocation.enabled']) == 'true'
+            ):
+                user_spark_opts['spark.executor.instances'] = str(DEFAULT_EXECUTOR_INSTANCES)
+
         if (
             'spark.mesos.executor.memoryOverhead' in user_spark_opts and
             'spark.executor.memoryOverhead' not in user_spark_opts

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -221,9 +221,10 @@ def _append_sql_shuffle_partitions_conf(spark_opts: Dict[str, str]) -> Dict[str,
         return spark_opts
 
     num_partitions = 2 * (
-        int(spark_opts.get('spark.dynamicAllocation.maxExecutors', 0)) * int(spark_opts.get('spark.executor.cores', 0))
-        or int(spark_opts.get('spark.cores.max', 0))
-        or int(spark_opts.get('spark.executor.instances', 0)) * int(spark_opts.get('spark.executor.cores', 0))
+        int(spark_opts.get('spark.dynamicAllocation.maxExecutors', 0)) *
+        int(spark_opts.get('spark.executor.cores', 0)) or
+        int(spark_opts.get('spark.cores.max', 0)) or
+        int(spark_opts.get('spark.executor.instances', 0)) * int(spark_opts.get('spark.executor.cores', 0))
     )
     log.warning(
         f'spark.sql.shuffle.partitions has been set to {num_partitions} '

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.10.1',
+    version='2.10.2',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -296,6 +296,55 @@ class TestGetSparkConf:
 
     @pytest.mark.parametrize(
         'cluster_manager,user_spark_opts,expected_output', [
+            # dynamic resource allocation enabled
+            (
+                'kubernetes',
+                {
+                    'spark.dynamicAllocation.enabled': 'true',
+                    'spark.executor.cores': '4',
+                    'spark.cores.max': '128',
+                },
+                {
+                    'spark.executor.memory': '4g',
+                    'spark.executor.cores': '4',
+                    'spark.executor.instances': '2',
+                    'spark.kubernetes.executor.limit.cores': '4',
+                    'spark.kubernetes.allocation.batch.size': '2',
+                    'spark.scheduler.maxRegisteredResourcesWaitingTime': '15min',
+                },
+            ),
+            # dynamic resource allocation disabled with instances specified
+            (
+                'kubernetes',
+                {
+                    'spark.dynamicAllocation.enabled': 'false',
+                    'spark.executor.instances': '600',
+                },
+                {
+                    'spark.executor.memory': '4g',
+                    'spark.executor.cores': '2',
+                    'spark.executor.instances': '600',
+                    'spark.kubernetes.executor.limit.cores': '2',
+                    'spark.kubernetes.allocation.batch.size': '512',
+                    'spark.scheduler.maxRegisteredResourcesWaitingTime': '35min',
+                },
+            ),
+            # dynamic resource allocation disabled with instances not specified
+            (
+                'kubernetes',
+                {
+                    'spark.executor.cores': '4',
+                    'spark.cores.max': '128',
+                },
+                {
+                    'spark.executor.memory': '4g',
+                    'spark.executor.cores': '4',
+                    'spark.executor.instances': '32',
+                    'spark.kubernetes.executor.limit.cores': '4',
+                    'spark.kubernetes.allocation.batch.size': '32',
+                    'spark.scheduler.maxRegisteredResourcesWaitingTime': '16min',
+                },
+            ),
             # use default k8s settings
             (
                 'kubernetes',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -568,39 +568,39 @@ class TestGetSparkConf:
             # dynamic resource allocation enabled, both maxExecutors and max cores defined
             (
                 {
-                    'spark.dynamicAllocation.enabled':'true',
+                    'spark.dynamicAllocation.enabled': 'true',
                     'spark.dynamicAllocation.maxExecutors': '128',
                     'spark.executor.cores': '3',
                     'spark.cores.max': '10',
                 },
-                '768', # max (2 * (max cores), 2 * (maxExecutors * executor cores))
+                '768',  # max (2 * (max cores), 2 * (maxExecutors * executor cores))
             ),
             # dynamic resource allocation enabled maxExecutors not defined, max cores defined
             (
-                    {
-                        'spark.dynamicAllocation.enabled': 'true',
-                        'spark.executor.cores': '3',
-                        'spark.cores.max': '10',
-                    },
-                    '20', # 2 * max cores
+                {
+                    'spark.dynamicAllocation.enabled': 'true',
+                    'spark.executor.cores': '3',
+                    'spark.cores.max': '10',
+                },
+                '20',  # 2 * max cores
             ),
             # dynamic resource allocation enabled maxExecutors not defined, max cores not defined
             (
-                    {
-                        'spark.dynamicAllocation.enabled': 'true',
-                        'spark.executor.cores': '3',
-                    },
-                    '128', # DEFAULT_SQL_SHUFFLE_PARTITIONS
+                {
+                    'spark.dynamicAllocation.enabled': 'true',
+                    'spark.executor.cores': '3',
+                },
+                '128',  # DEFAULT_SQL_SHUFFLE_PARTITIONS
             ),
             # dynamic resource allocation enabled maxExecutors infinity
             (
-                    {
-                        'spark.dynamicAllocation.enabled': 'true',
-                        'spark.dynamicAllocation.maxExecutors': 'infinity',
-                        'spark.executor.cores': '3',
-                        'spark.cores.max': '10',
-                    },
-                    '20', # 2 * max cores
+                {
+                    'spark.dynamicAllocation.enabled': 'true',
+                    'spark.dynamicAllocation.maxExecutors': 'infinity',
+                    'spark.executor.cores': '3',
+                    'spark.cores.max': '10',
+                },
+                '20',  # 2 * max cores
             ),
         ],
     )

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -549,11 +549,11 @@ class TestGetSparkConf:
             ({'spark.sql.shuffle.partitions': '300'}, '300'),
             # dynamic resource allocation enabled
             (
-                    {
-                        'spark.dynamicAllocation.maxExecutors': '128', 'spark.executor.cores': '3',
-                        'spark.cores.max': '10'
-                    },
-                    '768'
+                {
+                    'spark.dynamicAllocation.maxExecutors': '128', 'spark.executor.cores': '3',
+                    'spark.cores.max': '10',
+                },
+                '768',
             ),
         ],
     )

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -547,6 +547,14 @@ class TestGetSparkConf:
             ({'spark.executor.instances': '10', 'spark.executor.cores': '3'}, '60'),
             # user defined
             ({'spark.sql.shuffle.partitions': '300'}, '300'),
+            # dynamic resource allocation enabled
+            (
+                    {
+                        'spark.dynamicAllocation.maxExecutors': '128', 'spark.executor.cores': '3',
+                        'spark.cores.max': '10'
+                    },
+                    '768'
+            ),
         ],
     )
     def test_append_sql_shuffle_partitions_conf(


### PR DESCRIPTION
Disabling auto-calculation of executor instances with dynamic resource allocation (DRA):
- When DRA is enabled, the initial executors is decided based on  max(spark.dynamicAllocation.initialExecutors, spark.dynamicAllocation.minExecutors, **spark.executor.instances**)
- spark.executor.instances are auto-calculated if not provided by the user. This leads to incorrect initial configuration in case of DRA

Accurate num_partitions calculation in case of DRA:
- spark.sql.shuffle.partitions are calculated based on spark.cores.max and spark.executor.instances, both of which would not be present in case of DRA. spark.dynamicAllocation.maxExecutors should be used for this calculation.

Testing:
- Added unit tests
- make test