### PR TITLE
Add auto_set_temporary_credentials_provider to get_spark_conf for spark 3.2.0 support.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.10.5',
+    version='2.10.6',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -919,7 +919,8 @@ class TestGetSparkConf:
 
         return verify
 
-    def test_get_spark_conf_aws_session(self):
+    @pytest.mark.parametrize('use_temp_provider', [True, False])
+    def test_get_spark_conf_aws_session(self, use_temp_provider):
         other_spark_opts = {'spark.driver.memory': '2g', 'spark.executor.memoryOverhead': '1024'}
         not_allowed_opts = {'spark.executorEnv.PAASTA_SERVICE': 'random-service'}
         user_spark_opts = {
@@ -941,9 +942,13 @@ class TestGetSparkConf:
             docker_img=self.docker_image,
             extra_volumes=self.extra_volumes,
             aws_creds=aws_creds,
+            auto_set_temporary_credentials_provider=use_temp_provider,
         )
-        assert self.aws_provider_key in output.keys()
-        assert 'org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider' == output[self.aws_provider_key]
+        if use_temp_provider:
+            assert self.aws_provider_key in output.keys()
+            assert 'org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider' == output[self.aws_provider_key]
+        else:
+            assert self.aws_provider_key not in output
 
     def test_get_spark_conf_mesos(
         self,


### PR DESCRIPTION
Should be backwards compatible and will follow this up with changes to paasta and spark_tools to set this new option to false.