### PR TITLE
MLCOMPUTE-23 | Enable DRA using recommended configs

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -73,6 +73,7 @@ NON_CONFIGURABLE_SPARK_OPTS = {
 K8S_AUTH_FOLDER = '/etc/pki/spark'
 
 log = logging.Logger(__name__)
+log.setLevel(logging.INFO)
 
 
 def _load_aws_credentials_from_yaml(yaml_file_path) -> Tuple[str, str, Optional[str]]:
@@ -288,18 +289,18 @@ def _get_dra_configs(spark_opts: Dict[str, str]) -> Dict[str, str]:
             )
 
         spark_opts['spark.dynamicAllocation.minExecutors'] = str(min_executors)
-        log.info(
-            f'Setting spark.dynamicAllocation.minExecutors as {min_executors}. If you wish to '
+        log.warning(
+            f'\nSetting spark.dynamicAllocation.minExecutors as {min_executors}. If you wish to '
             f'change the value of minimum executors, please provide the exact value of '
-            f'spark.dynamicAllocation.minExecutors in --spark-args',
+            f'spark.dynamicAllocation.minExecutors in --spark-args\n',
         )
 
         if 'spark.yelp.dra.minExecutorRatio' not in spark_opts:
             log.debug(
-                f'spark.yelp.dra.minExecutorRatio not provided. This specifies the ratio of total executors '
+                f'\nspark.yelp.dra.minExecutorRatio not provided. This specifies the ratio of total executors '
                 f'to be used as minimum executors for Dynamic Resource Allocation. More info: y/spark-dra. Using '
                 f'default ratio: {DEFAULT_DRA_MIN_EXECUTOR_RATIO}. If you wish to change this value, please provide '
-                f'the desired spark.yelp.dra.minExecutorRatio in --spark-args',
+                f'the desired spark.yelp.dra.minExecutorRatio in --spark-args\n',
             )
 
     if 'spark.dynamicAllocation.maxExecutors' not in spark_opts:
@@ -310,10 +311,10 @@ def _get_dra_configs(spark_opts: Dict[str, str]) -> Dict[str, str]:
             max_executors = max(max_executors, int(spark_opts['spark.dynamicAllocation.initialExecutors']))
 
         spark_opts['spark.dynamicAllocation.maxExecutors'] = str(max_executors)
-        log.info(
-            f'Setting spark.dynamicAllocation.maxExecutors as {max_executors}. If you wish to '
+        log.warning(
+            f'\nSetting spark.dynamicAllocation.maxExecutors as {max_executors}. If you wish to '
             f'change the value of maximum executors, please provide the exact value of '
-            f'spark.dynamicAllocation.maxExecutors in --spark-args',
+            f'spark.dynamicAllocation.maxExecutors in --spark-args\n',
         )
 
     spark_opts['spark.executor.instances'] = spark_opts['spark.dynamicAllocation.minExecutors']

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.10.6',
+    version='2.10.7',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -542,7 +542,6 @@ class TestGetSparkConf:
             expected_output,
     ):
         output = spark_config._get_dra_configs(user_spark_opts)
-        print(output)
         for key in expected_output.keys():
             assert output[key] == expected_output[key], f'wrong value for {key}'
 


### PR DESCRIPTION
This enables Dynamic Resource Allocation (DRA) for spark jobs through a flag --enable-dra in paasta spark-run which translates to spark.dynamicAllocation.enabled=true. The config values used for enabling DRA are tested on 15+ batches and recommended here: y/spark-dra
This does not override the config values if they are specified in --spark-args.
Also added a new configurable config 'spark.yelp.dra.minExecutorRatio' which specifies the ratio of total executors to be used as minExecutors for DRA, the default value being 0.25

PR for --enable-dra flag in paasta: https://github.com/Yelp/paasta/pull/3386

Testing: 
- Unit tests
- Tested this with paasta using: https://yelpwiki.yelpcorp.com/pages/viewpage.action?pageId=208483399#Sparkdevelopmentrunbook-Method1: