### PR TITLE
MLCOMPUTE-36 | change default cachedExecutorIdleTimeout and expose get_dra_configs as public

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -275,7 +275,8 @@ def get_dra_configs(spark_opts: Dict[str, str]) -> Dict[str, str]:
         f'\nSetting spark.dynamicAllocation.cachedExecutorIdleTimeout as {DEFAULT_DRA_CACHED_EXECUTOR_IDLE_TIMEOUT}. '
         f'Executor with cached data block will be released if it has been idle for this duration. '
         f'If you wish to change the value of cachedExecutorIdleTimeout, please provide the exact value of '
-        f'spark.dynamicAllocation.cachedExecutorIdleTimeout in --spark-args\n',
+        f'spark.dynamicAllocation.cachedExecutorIdleTimeout in --spark-args. If your job is performing bad because '
+        f'the cached data was lost, please consider increasing this value.\n',
     )
 
     if 'spark.dynamicAllocation.minExecutors' not in spark_opts:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.10.7',
+    version='2.10.8',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -475,7 +475,7 @@ class TestGetSparkConf:
                     'spark.dynamicAllocation.enabled': 'true',
                     'spark.dynamicAllocation.shuffleTracking.enabled': 'true',
                     'spark.dynamicAllocation.executorAllocationRatio': '0.8',
-                    'spark.dynamicAllocation.cachedExecutorIdleTimeout': '420s',
+                    'spark.dynamicAllocation.cachedExecutorIdleTimeout': '900s',
                     'spark.dynamicAllocation.minExecutors': '0',
                     'spark.dynamicAllocation.maxExecutors': '2',
                     'spark.executor.instances': '0',
@@ -495,7 +495,7 @@ class TestGetSparkConf:
                     'spark.dynamicAllocation.initialExecutors': '128',
                     'spark.dynamicAllocation.shuffleTracking.enabled': 'true',
                     'spark.dynamicAllocation.executorAllocationRatio': '0.8',
-                    'spark.dynamicAllocation.cachedExecutorIdleTimeout': '420s',
+                    'spark.dynamicAllocation.cachedExecutorIdleTimeout': '900s',
                     'spark.executor.instances': '128',
                 },
             ),
@@ -510,7 +510,7 @@ class TestGetSparkConf:
                     'spark.dynamicAllocation.minExecutors': '205',
                     'spark.dynamicAllocation.shuffleTracking.enabled': 'true',
                     'spark.dynamicAllocation.executorAllocationRatio': '0.8',
-                    'spark.dynamicAllocation.cachedExecutorIdleTimeout': '420s',
+                    'spark.dynamicAllocation.cachedExecutorIdleTimeout': '900s',
                     'spark.executor.instances': '205',
                 },
             ),
@@ -541,7 +541,7 @@ class TestGetSparkConf:
             user_spark_opts,
             expected_output,
     ):
-        output = spark_config._get_dra_configs(user_spark_opts)
+        output = spark_config.get_dra_configs(user_spark_opts)
         for key in expected_output.keys():
             assert output[key] == expected_output[key], f'wrong value for {key}'
 


### PR DESCRIPTION
The value of cachedExecutorIdleTimeout increased to 15 min = 900 sec for batches which use their cache at a later point in the application.
Exposed the get_dra_configs method as public to update dra configs in paasta: https://github.com/Yelp/paasta/pull/3408

