### PR TITLE
MLCOMPUTE-439 | modified executor instance calculation in absence of spark.cores.max

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -433,9 +433,13 @@ def _adjust_spark_requested_resources(
             # spark.cores.max provided, calculate based on (max cores // per-executor cores)
             if 'spark.cores.max' in user_spark_opts:
                 executor_instances = int(user_spark_opts['spark.cores.max']) // executor_cores
-            # spark.executor.instances and spark.cores.max not provided, the executor instances should at least
-            # be equal to DEFAULT_EXECUTOR_INSTANCES.
+                log.warning(
+                    f'spark.cores.max should be replaced and the exact value of spark.executor.instances '
+                    f'should be provided in --spark-args',
+                )
             else:
+                # spark.executor.instances and spark.cores.max not provided, the executor instances should at least
+                # be equal to DEFAULT_EXECUTOR_INSTANCES.
                 executor_instances = max(DEFAULT_MAX_CORES // executor_cores, DEFAULT_EXECUTOR_INSTANCES)
             user_spark_opts['spark.executor.instances'] = str(executor_instances)
 

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -430,9 +430,11 @@ def _adjust_spark_requested_resources(
         # TODO(gcoll|COREML-2697): Consider cleaning this part of the code up
         # once mesos is not longer around at Yelp.
         if 'spark.executor.instances' not in user_spark_opts:
-
+            # spark.cores.max provided, calculate based on (max cores // per-executor cores)
             if 'spark.cores.max' in user_spark_opts:
                 executor_instances = int(user_spark_opts['spark.cores.max']) // executor_cores
+            # spark.executor.instances and spark.cores.max not provided, the executor instances should at least
+            # be equal to DEFAULT_EXECUTOR_INSTANCES.
             else:
                 executor_instances = max(DEFAULT_MAX_CORES // executor_cores, DEFAULT_EXECUTOR_INSTANCES)
             user_spark_opts['spark.executor.instances'] = str(executor_instances)

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -431,13 +431,13 @@ def _adjust_spark_requested_resources(
         # once mesos is not longer around at Yelp.
         if 'spark.executor.instances' not in user_spark_opts:
 
-            executor_instances = int(user_spark_opts.get(
-                'spark.cores.max',
-                str(DEFAULT_MAX_CORES),
-            )) // executor_cores
+            if 'spark.cores.max' in user_spark_opts:
+                executor_instances = int(user_spark_opts['spark.cores.max']) // executor_cores
+            else:
+                executor_instances = max(DEFAULT_MAX_CORES // executor_cores, DEFAULT_EXECUTOR_INSTANCES)
             user_spark_opts['spark.executor.instances'] = str(executor_instances)
 
-            if user_spark_opts['spark.executor.instances'] == str(DEFAULT_EXECUTOR_INSTANCES):
+            if user_spark_opts['spark.executor.instances'] <= str(DEFAULT_EXECUTOR_INSTANCES):
                 log.warning(
                     f'spark.executor.instances not provided. Setting spark.executor.instances as '
                     f'{executor_instances}. If you wish to change the number of executors, please '

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -417,6 +417,9 @@ def _append_aws_credentials_conf(
 
 
 def compute_executor_instances_k8s(user_spark_opts: Dict[str, str]) -> int:
+    if 'spark.executor.instances' in user_spark_opts:
+        return int(user_spark_opts['spark.executor.instances'])
+
     executor_cores = int(user_spark_opts.get('spark.executor.cores', DEFAULT_EXECUTOR_CORES))
     if 'spark.cores.max' in user_spark_opts:
         # spark.cores.max provided, calculate based on (max cores // per-executor cores)
@@ -429,7 +432,6 @@ def compute_executor_instances_k8s(user_spark_opts: Dict[str, str]) -> int:
         # spark.executor.instances and spark.cores.max not provided, the executor instances should at least
         # be equal to DEFAULT_EXECUTOR_INSTANCES.
         executor_instances = max(DEFAULT_MAX_CORES // executor_cores, DEFAULT_EXECUTOR_INSTANCES)
-
     return executor_instances
 
 
@@ -444,10 +446,8 @@ def _adjust_spark_requested_resources(
         max_cores = int(user_spark_opts.setdefault('spark.cores.max', str(DEFAULT_MAX_CORES)))
         executor_instances = max_cores / executor_cores
     elif cluster_manager == 'kubernetes':
-        if 'spark.executor.instances' not in user_spark_opts:
-            user_spark_opts['spark.executor.instances'] = str(compute_executor_instances_k8s(user_spark_opts))
-
-        executor_instances = int(user_spark_opts['spark.executor.instances'])
+        executor_instances = compute_executor_instances_k8s(user_spark_opts)
+        user_spark_opts.setdefault('spark.executor.instances', str(executor_instances))
         max_cores = executor_instances * executor_cores
         if (
             'spark.mesos.executor.memoryOverhead' in user_spark_opts and

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.11.0',
+    version='2.11.1',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.12.0',
+    version='2.12.1',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',


### PR DESCRIPTION
- Currently, if a user provides `spark.executor.cores` but does not provide `spark.cores.max` and `spark.executor.instances`, `spark.executor.instances` will be calculated based on the (default value of `spark.cores.max` //  `spark.executor.cores`). This can lead to executors being set as 0 or a low value. If the user has not specified `spark.cores.max` and `spark.executor.instances`, this should signify that the user wants at least the default number of executors. The changes in the code are corresponding to this logic.