### PR TITLE
make Spark on Mesos use old spark shuffle fetch protocol

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-importlib-resources==1.5.0
+importlib-resources==5.4.0
 pyinotify==0.9.6
 pyyaml >= 3.0

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -616,6 +616,7 @@ def _get_mesos_spark_env(
         'spark.mesos.constraints': f'pool:{paasta_pool}',
         'spark.mesos.executor.docker.forcePullImage': 'true',
         'spark.mesos.principal': 'spark',
+        'spark.shuffle.useOldFetchProtocol': 'true',
         **auth_configs,
         **_get_mesos_docker_volumes_conf(
             user_spark_opts, extra_volumes,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.11.0',
+    version='2.11.1',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -929,6 +929,7 @@ class TestGetSparkConf:
                 'spark.mesos.executor.docker.forcePullImage': 'true',
                 'spark.mesos.constraints': f'pool:{self.pool}',
                 'spark.mesos.principal': 'spark',
+                'spark.shuffle.useOldFetchProtocol': 'true',
             }
             for key, value in expected_output.items():
                 assert output[key] == value


### PR DESCRIPTION
Spark 3 introduced a new shuffle protocol (see [Apache Spark's migration guide](https://spark.apache.org/docs/3.2.0/core-migration-guide.html#upgrading-from-core-24-to-30) for more descriptions). Upon upgrading to Spark 3.2 it seems like we are running into issue with this new protocol on Mesos clusters, therefore we force spark to use the old fetch protocol to make spark on mesos work.

This doesn't seem to be a problem for spark on k8s so this is not added to the k8s configs. 

`make test` passed.