### PR TITLE
Update signalfx link to use y/spark-metrics

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -903,13 +903,13 @@ def compute_requested_memory_overhead(spark_opts: Mapping[str, str], executor_me
 
 def get_signalfx_url(spark_conf: Mapping[str, str]) -> str:
     return (
-        'https://app.signalfx.com/#/dashboard/DJzYJDkAcAA?density=4'
+        'https://app.signalfx.com/#/dashboard/FOjL2yRAcAA?density=4'
         '&variables%5B%5D=Instance%3Dinstance_name:'
         '&variables%5B%5D=Service%3Dservice_name:%5B%22spark%22%5D'
         f"&variables%5B%5D=PaaSTA%20Cluster%3Dpaasta_cluster:{spark_conf['spark.executorEnv.PAASTA_CLUSTER']}"
         f"&variables%5B%5D=PaaSTA%20Service%3Dpaasta_service:{spark_conf['spark.executorEnv.PAASTA_SERVICE']}"
         f"&variables%5B%5D=PaaSTA%20Instance%3Dpaasta_instance:{spark_conf['spark.executorEnv.PAASTA_INSTANCE']}"
-        '&startTime=-6h&endTime=Now'
+        '&startTime=-1h&endTime=Now'
     )
 
 

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -1305,13 +1305,13 @@ def test_get_signalfx_url():
         'spark.executorEnv.PAASTA_INSTANCE': 'test-instance',
     }
     assert spark_config.get_signalfx_url(spark_conf) == (
-        'https://app.signalfx.com/#/dashboard/DJzYJDkAcAA?density=4'
+        'https://app.signalfx.com/#/dashboard/FOjL2yRAcAA?density=4'
         '&variables%5B%5D=Instance%3Dinstance_name:'
         '&variables%5B%5D=Service%3Dservice_name:%5B%22spark%22%5D'
         '&variables%5B%5D=PaaSTA%20Cluster%3Dpaasta_cluster:test-cluster'
         '&variables%5B%5D=PaaSTA%20Service%3Dpaasta_service:test-service'
         '&variables%5B%5D=PaaSTA%20Instance%3Dpaasta_instance:test-instance'
-        '&startTime=-6h&endTime=Now'
+        '&startTime=-1h&endTime=Now'
     )
 
 


### PR DESCRIPTION
Use y/spark-metrics which is more catered towards spark metrics than the status-quo y/paasta-status
