### PR TITLE
Add labels to spark pods to complete CLUSTERMAN-582

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -662,6 +662,7 @@ def _get_k8s_spark_env(
         'spark.kubernetes.executor.label.paasta.yelp.com/cluster': _paasta_cluster,
         'spark.kubernetes.node.selector.yelp.com/pool': paasta_pool,
         'spark.kubernetes.executor.label.yelp.com/pool': paasta_pool,
+        'spark.kubernetes.executor.label.paasta.yelp.com/pool': paasta_pool,
         **_get_k8s_docker_volumes_conf(volumes),
     }
     return spark_env

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -1060,6 +1060,7 @@ class TestGetSparkConf:
             'spark.kubernetes.executor.label.paasta.yelp.com/cluster': self.cluster,
             'spark.kubernetes.node.selector.yelp.com/pool': self.pool,
             'spark.kubernetes.executor.label.yelp.com/pool': self.pool,
+            'spark.kubernetes.executor.label.paasta.yelp.com/pool': self.pool,
             'spark.logConf': 'true',
             'spark.ui.showConsoleProgress': 'true',
         }


### PR DESCRIPTION
batch and stabel_batch pool pods, do not have the `paasta.yelp.com/pool label` for the pods, this PR adds them. The labels are required to enable label based auto-scaling in pnw-devc


Clusterman PR - https://github.com/Yelp/clusterman/pull/177