### PR TITLE
get_spark_conf now sets additional spark.sql configs related to default partitioning.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v3.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -20,8 +20,8 @@ repos:
     rev: v1.4.3
     hooks:
     -   id: autopep8
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.1
+-   repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
     hooks:
     -   id: flake8
 -   repo: https://github.com/asottile/reorder_python_imports

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -235,11 +235,8 @@ def _append_spark_config(spark_opts: Dict[str, str], config_name: str, config_va
     return spark_opts
 
 
-def _append_sql_shuffle_partitions_conf(spark_opts: Dict[str, str]) -> Dict[str, str]:
-    if 'spark.sql.shuffle.partitions' in spark_opts:
-        return spark_opts
-
-    num_partitions = 2 * (
+def _append_sql_partitions_conf(spark_opts: Dict[str, str]) -> Dict[str, str]:
+    num_partitions = 3 * (
         int(spark_opts.get('spark.cores.max', 0)) or
         int(spark_opts.get('spark.executor.instances', 0)) *
         int(spark_opts.get('spark.executor.cores', DEFAULT_EXECUTOR_CORES))
@@ -252,22 +249,17 @@ def _append_sql_shuffle_partitions_conf(spark_opts: Dict[str, str]) -> Dict[str,
         str(spark_opts['spark.dynamicAllocation.maxExecutors']) != 'infinity'
     ):
 
-        num_partitions_dra = 2 * (
+        num_partitions_dra = 3 * (
             int(spark_opts.get('spark.dynamicAllocation.maxExecutors', 0)) *
             int(spark_opts.get('spark.executor.cores', DEFAULT_EXECUTOR_CORES))
         )
         num_partitions = max(num_partitions, num_partitions_dra)
 
     num_partitions = num_partitions or DEFAULT_SQL_SHUFFLE_PARTITIONS
+    _append_spark_config(spark_opts, 'spark.sql.shuffle.partitions', str(num_partitions))
+    _append_spark_config(spark_opts, 'spark.sql.files.minPartitionNum', str(num_partitions))
+    _append_spark_config(spark_opts, 'spark.default.parallelism', str(num_partitions))
 
-    log.warning(
-        f'spark.sql.shuffle.partitions has been set to {num_partitions} '
-        'to be equal to twice the number of requested cores, but you should '
-        'consider setting a higher value if necessary.'
-        ' Follow y/spark for help on partition sizing',
-    )
-
-    spark_opts['spark.sql.shuffle.partitions'] = str(num_partitions)
     return spark_opts
 
 
@@ -883,7 +875,7 @@ def get_spark_conf(
     spark_conf = _append_event_log_conf(spark_conf, *aws_creds)
 
     # configure sql shuffle partitions
-    spark_conf = _append_sql_shuffle_partitions_conf(spark_conf)
+    spark_conf = _append_sql_partitions_conf(spark_conf)
 
     # configure spark conf log
     spark_conf = _append_spark_config(spark_conf, 'spark.logConf', 'true')

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -249,7 +249,7 @@ def _append_sql_partitions_conf(spark_opts: Dict[str, str]) -> Dict[str, str]:
         str(spark_opts['spark.dynamicAllocation.maxExecutors']) != 'infinity'
     ):
 
-        num_partitions_dra = 3 * (
+        num_partitions_dra = (
             int(spark_opts.get('spark.dynamicAllocation.maxExecutors', 0)) *
             int(spark_opts.get('spark.executor.cores', DEFAULT_EXECUTOR_CORES))
         )

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -414,8 +414,8 @@ def compute_executor_instances_k8s(user_spark_opts: Dict[str, str]) -> int:
         # spark.cores.max provided, calculate based on (max cores // per-executor cores)
         executor_instances = (int(user_spark_opts['spark.cores.max']) // executor_cores)
         log.warning(
-            f'spark.cores.max should no longer be provided and should be replaced '
-            f'by the exact value of spark.executor.instances in --spark-args',
+            'spark.cores.max should no longer be provided and should be replaced '
+            'by the exact value of spark.executor.instances in --spark-args',
         )
     else:
         # spark.executor.instances and spark.cores.max not provided, the executor instances should at least

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.12.3',
+    version='2.12.4',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -72,7 +72,7 @@ class TestGetAWSCredentials:
     def test_use_service_credentials(self, tmpdir, monkeypatch):
         test_service = 'test_service'
         creds_dir = tmpdir.mkdir('creds')
-        creds_file = creds_dir.join(f'test_service.yaml')
+        creds_file = creds_dir.join('test_service.yaml')
         creds_file.write(yaml.dump(self.creds))
         monkeypatch.setattr(spark_config, 'AWS_CREDENTIALS_DIR', str(creds_dir))
         assert spark_config.get_aws_credentials(service=test_service) == self.expected_creds

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -613,7 +613,7 @@ class TestGetSparkConf:
                     'spark.executor.cores': '3',
                     'spark.cores.max': '10',
                 },
-                '1152',  # max (3 * (max cores), 3 * (maxExecutors * executor cores))
+                '384',  # max (3 * (max cores), (maxExecutors * executor cores))
             ),
             # dynamic resource allocation enabled maxExecutors not defined, max cores defined
             (

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -600,11 +600,11 @@ class TestGetSparkConf:
     @pytest.mark.parametrize(
         'user_spark_opts,expected_output', [
             # mesos
-            ({'spark.cores.max': '10'}, '20'),
+            ({'spark.cores.max': '10'}, '30'),
             # k8s
-            ({'spark.executor.instances': '10', 'spark.executor.cores': '3'}, '60'),
+            ({'spark.executor.instances': '10', 'spark.executor.cores': '3'}, '90'),
             # user defined
-            ({'spark.sql.shuffle.partitions': '300'}, '300'),
+            ({'spark.sql.shuffle.partitions': '300'}, ['300', '128', '128']),
             # dynamic resource allocation enabled, both maxExecutors and max cores defined
             (
                 {
@@ -613,7 +613,7 @@ class TestGetSparkConf:
                     'spark.executor.cores': '3',
                     'spark.cores.max': '10',
                 },
-                '768',  # max (2 * (max cores), 2 * (maxExecutors * executor cores))
+                '1152',  # max (3 * (max cores), 3 * (maxExecutors * executor cores))
             ),
             # dynamic resource allocation enabled maxExecutors not defined, max cores defined
             (
@@ -622,7 +622,7 @@ class TestGetSparkConf:
                     'spark.executor.cores': '3',
                     'spark.cores.max': '10',
                 },
-                '20',  # 2 * max cores
+                '30',  # 2 * max cores
             ),
             # dynamic resource allocation enabled maxExecutors not defined, max cores not defined
             (
@@ -640,16 +640,23 @@ class TestGetSparkConf:
                     'spark.executor.cores': '3',
                     'spark.cores.max': '10',
                 },
-                '20',  # 2 * max cores
+                '30',  # 2 * max cores
             ),
         ],
     )
-    def test_append_sql_shuffle_partitions_conf(
+    def test_append_sql_partitions_conf(
         self, user_spark_opts, expected_output,
     ):
-        output = spark_config._append_sql_shuffle_partitions_conf(user_spark_opts)
-        key = 'spark.sql.shuffle.partitions'
-        assert output[key] == expected_output
+        output = spark_config._append_sql_partitions_conf(user_spark_opts)
+        keys = [
+            'spark.sql.shuffle.partitions',
+            'spark.sql.files.minPartitionNum',
+            'spark.default.parallelism',
+        ]
+        if isinstance(expected_output, str):
+            expected_output = [expected_output] * 3
+        for key, expected in zip(keys, expected_output):
+            assert output[key] == expected
 
     @pytest.mark.parametrize(
         'user_spark_opts,expected_output', [
@@ -717,10 +724,15 @@ class TestGetSparkConf:
             yield m
 
     @pytest.fixture
-    def mock_append_sql_shuffle_partitions_conf(self):
-        return_value = {'spark.sql.shuffle.partitions': '10'}
+    def mock_append_sql_partitions_conf(self):
+        keys = [
+            'spark.sql.shuffle.partitions',
+            'spark.sql.files.minPartitionNum',
+            'spark.default.parallelism',
+        ]
+        return_value = {k: '10' for k in keys}
         with MockConfigFunction(
-            '_append_sql_shuffle_partitions_conf', return_value,
+            '_append_sql_partitions_conf', return_value,
         ) as m:
             yield m
 
@@ -948,7 +960,7 @@ class TestGetSparkConf:
         mock_get_mesos_docker_volumes_conf,
         mock_append_event_log_conf,
         mock_append_aws_credentials_conf,
-        mock_append_sql_shuffle_partitions_conf,
+        mock_append_sql_partitions_conf,
         mock_adjust_spark_requested_resources_mesos,
         mock_time,
         assert_mesos_leader,
@@ -1006,7 +1018,7 @@ class TestGetSparkConf:
             list(mock_adjust_spark_requested_resources_mesos.return_value.keys()) +
             list(mock_append_event_log_conf.return_value.keys()) +
             list(mock_append_aws_credentials_conf.return_value.keys()) +
-            list(mock_append_sql_shuffle_partitions_conf.return_value.keys()) +
+            list(mock_append_sql_partitions_conf.return_value.keys()) +
             list(mock_append_spark_conf_log.return_value.keys()) +
             list(mock_append_console_progress_conf.return_value.keys()),
         )
@@ -1021,7 +1033,7 @@ class TestGetSparkConf:
             mock.ANY, *aws_creds,
         )
         mock_append_aws_credentials_conf.mocker.assert_called_once_with(mock.ANY, *aws_creds, aws_region)
-        mock_append_sql_shuffle_partitions_conf.mocker.assert_called_once_with(
+        mock_append_sql_partitions_conf.mocker.assert_called_once_with(
             mock.ANY,
         )
         (warning_msg,), _ = mock_log.warning.call_args
@@ -1086,7 +1098,7 @@ class TestGetSparkConf:
         base_volumes,
         mock_append_event_log_conf,
         mock_append_aws_credentials_conf,
-        mock_append_sql_shuffle_partitions_conf,
+        mock_append_sql_partitions_conf,
         mock_adjust_spark_requested_resources_kubernetes,
         mock_time,
         assert_ui_port,
@@ -1126,7 +1138,7 @@ class TestGetSparkConf:
             list(mock_adjust_spark_requested_resources_kubernetes.return_value.keys()) +
             list(mock_append_event_log_conf.return_value.keys()) +
             list(mock_append_aws_credentials_conf.return_value.keys()) +
-            list(mock_append_sql_shuffle_partitions_conf.return_value.keys()),
+            list(mock_append_sql_partitions_conf.return_value.keys()),
         )
         assert set(output.keys()) == verified_keys
         mock_adjust_spark_requested_resources_kubernetes.mocker.assert_called_once_with(
@@ -1136,7 +1148,7 @@ class TestGetSparkConf:
             mock.ANY, *aws_creds,
         )
         mock_append_aws_credentials_conf.mocker.assert_called_once_with(mock.ANY, *aws_creds, aws_region)
-        mock_append_sql_shuffle_partitions_conf.mocker.assert_called_once_with(
+        mock_append_sql_partitions_conf.mocker.assert_called_once_with(
             mock.ANY,
         )
 
@@ -1173,7 +1185,7 @@ class TestGetSparkConf:
         base_volumes,
         mock_append_event_log_conf,
         mock_append_aws_credentials_conf,
-        mock_append_sql_shuffle_partitions_conf,
+        mock_append_sql_partitions_conf,
         mock_adjust_spark_requested_resources_kubernetes,
         mock_time,
         assert_ui_port,
@@ -1204,7 +1216,7 @@ class TestGetSparkConf:
             list(mock_append_event_log_conf.return_value.keys()) +
             list(mock_adjust_spark_requested_resources_kubernetes.return_value.keys()) +
             list(mock_append_aws_credentials_conf.return_value.keys()) +
-            list(mock_append_sql_shuffle_partitions_conf.return_value.keys()),
+            list(mock_append_sql_partitions_conf.return_value.keys()),
         )
         assert set(output.keys()) == verified_keys
         mock_append_event_log_conf.mocker.assert_called_once_with(
@@ -1214,7 +1226,7 @@ class TestGetSparkConf:
             mock.ANY, 'local', self.pool,
         )
         mock_append_aws_credentials_conf.mocker.assert_called_once_with(mock.ANY, *aws_creds, aws_region)
-        mock_append_sql_shuffle_partitions_conf.mocker.assert_called_once_with(
+        mock_append_sql_partitions_conf.mocker.assert_called_once_with(
             mock.ANY,
         )
 


### PR DESCRIPTION
- Set some additional configs to be inline with the shuffle partition numbers
- Increased the multiplier to 3x instead of 2x.  This one is kind of arbitrary but my thinking is that a bit more flexibility could improve load balancing and/or DRA scale up time.  It might not really matter.
- Fix tests that I broke in the process.