### PR TITLE
Cap executor resource with instance count adjustment

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -537,10 +537,9 @@ def _recalculate_executor_resources(
             new_memory = new_cpu * TARGET_MEM_CPU_RATIO
         log.warning(
             f'Given executor resources: {cpu}cores, {memory}g {instances} instances '
-            f'=> adjusted to {new_cpu}cores {new_memory} {new_instances} instances, '
-            f'based on recommended Mem:Core category {target_memory}g, {target_memory/TARGET_MEM_CPU_RATIO} '
-            f'and Mem:core ratio: {TARGET_MEM_CPU_RATIO}:1. \n '
-            f'to better fit on available aws nodes.',
+            f'=> adjusted to {new_cpu}cores {new_memory}g {new_instances} instances, '
+            f'based on recommended Mem:Core category {target_memory}g, {target_memory//TARGET_MEM_CPU_RATIO}cores '
+            f'and Mem:core ratio: {TARGET_MEM_CPU_RATIO}:1 to better fit on available aws nodes.',
         )
 
         if new_cpu < task_cpus:

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -50,7 +50,7 @@ RECOMMENDED_RESOURCE_CONFIGS: Dict[str, ExecutorResourceConfig] = {
 }
 TARGET_MEM_CPU_RATIO = 7
 
-DEFAULT_MAX_CORES = 4
+DEFAULT_MAX_CORES = RECOMMENDED_RESOURCE_CONFIGS['recommended'].executor_cores
 DEFAULT_EXECUTOR_CORES = 2
 DEFAULT_EXECUTOR_INSTANCES = 2
 DEFAULT_EXECUTOR_MEMORY = RECOMMENDED_RESOURCE_CONFIGS['recommended'].executor_memory
@@ -491,7 +491,6 @@ def _cap_executor_resources(
     executor_memory: str,
     memory_mb: int,
 ) -> Tuple[int, str]:
-    recommended_memory_gb = RECOMMENDED_RESOURCE_CONFIGS['recommended'].executor_memory
     max_cores = RECOMMENDED_RESOURCE_CONFIGS['max'].executor_cores
     max_memory_gb = RECOMMENDED_RESOURCE_CONFIGS['max'].executor_memory
 
@@ -505,11 +504,6 @@ def _cap_executor_resources(
             f'  - spark.executor.memory:    {int(memory_mb / 1024):3}g  → {executor_memory}',
         )
         warning_title_printed = True
-    elif memory_mb > recommended_memory_gb * 1024:
-        log.warning(
-            f'Recommended value for spark config spark.executor.memory:  {recommended_memory_gb}g '
-            f'and spark.executor.cores as {DEFAULT_MAX_CORES} and adjust spark.executor.instances proportionately.\n',
-        )
 
     if executor_cores > max_cores:
         if not warning_title_printed:

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -329,7 +329,7 @@ class TestGetSparkConf:
                 'kubernetes',
                 {},
                 {
-                    'spark.executor.memory': '4g',
+                    'spark.executor.memory': '28g',
                     'spark.executor.cores': '2',
                     'spark.executor.instances': '2',
                     'spark.kubernetes.executor.limit.cores': '2',
@@ -346,7 +346,7 @@ class TestGetSparkConf:
                     'spark.executor.instances': '600',
                 },
                 {
-                    'spark.executor.memory': '4g',
+                    'spark.executor.memory': '28g',
                     'spark.executor.cores': '2',
                     'spark.executor.instances': '600',
                     'spark.kubernetes.executor.limit.cores': '2',
@@ -382,7 +382,7 @@ class TestGetSparkConf:
                 'mesos',
                 {},
                 {
-                    'spark.executor.memory': '4g',
+                    'spark.executor.memory': '28g',
                     'spark.executor.cores': '2',
                     'spark.cores.max': '4',
                 },
@@ -421,7 +421,7 @@ class TestGetSparkConf:
                 },
                 False,
             ),
-            # user defined resources - recalculated
+            # user defined resources - recalculated - medium memory
             (
                 'mesos',
                 {
@@ -439,7 +439,7 @@ class TestGetSparkConf:
                 },
                 False,
             ),
-            # user defined resources - recalculated
+            # user defined resources - recalculated - medium memory
             (
                 'mesos',
                 {
@@ -457,7 +457,7 @@ class TestGetSparkConf:
                 },
                 False,
             ),
-            # user defined resources - not recalculated
+            # user defined resources - recalculated - recommended memory
             (
                 'mesos',
                 {
@@ -469,7 +469,25 @@ class TestGetSparkConf:
                 },
                 {
                     'spark.executor.cores': '4',
-                    'spark.executor.memory': '32g',
+                    'spark.executor.memory': '28g',
+                    'spark.executor.instances': '1',
+                    'spark.cores.max': '32',
+                },
+                False,
+            ),
+            # user defined resources - not recalculated
+            (
+                'mesos',
+                {
+                    'spark.executor.cores': '4',
+                    'spark.executor.memory': '8g',
+                    'spark.executor.instances': '1',
+                    'spark.cores.max': '32',
+
+                },
+                {
+                    'spark.executor.cores': '4',
+                    'spark.executor.memory': '8g',
                     'spark.executor.instances': '1',
                     'spark.cores.max': '32',
                 },
@@ -521,7 +539,7 @@ class TestGetSparkConf:
                     'spark.default.parallelism': '2',
                     'spark.task.cpus': '8',
                     'spark.executor.cores': '8',
-                    'spark.executor.memory': '4g',
+                    'spark.executor.memory': '28g',
                     'spark.cores.max': '16',
                 },
                 False,

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -403,7 +403,7 @@ class TestGetSparkConf:
                 },
                 False,
             ),
-            # user defined resources - recalculated - medium memory
+            # user defined resources - capped cpu & memory
             (
                 'mesos',
                 {
@@ -414,9 +414,9 @@ class TestGetSparkConf:
 
                 },
                 {
-                    'spark.executor.cores': '8',
-                    'spark.executor.memory': '56g',
-                    'spark.executor.instances': '4',
+                    'spark.executor.cores': '12',
+                    'spark.executor.memory': '110g',
+                    'spark.executor.instances': '2',
                     'spark.cores.max': '32',
                 },
                 False,

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -464,14 +464,13 @@ class TestGetSparkConf:
                 {
                     'spark.executor.cores': '4',
                     'spark.executor.memory': '32g',
-                    'spark.executor.instances': '2',
+                    'spark.executor.instances': '8',
                     'spark.cores.max': '32',
-
                 },
                 {
                     'spark.executor.cores': '4',
                     'spark.executor.memory': '28g',
-                    'spark.executor.instances': '2',
+                    'spark.executor.instances': '9',
                     'spark.cores.max': '32',
                 },
                 False,

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -330,7 +330,7 @@ class TestGetSparkConf:
                 {},
                 {
                     'spark.executor.memory': '28g',
-                    'spark.executor.cores': '2',
+                    'spark.executor.cores': '4',
                     'spark.executor.instances': '2',
                     'spark.kubernetes.executor.limit.cores': '2',
                     'spark.kubernetes.allocation.batch.size': '512',
@@ -347,7 +347,7 @@ class TestGetSparkConf:
                 },
                 {
                     'spark.executor.memory': '28g',
-                    'spark.executor.cores': '2',
+                    'spark.executor.cores': '4',
                     'spark.executor.instances': '600',
                     'spark.kubernetes.executor.limit.cores': '2',
                     'spark.kubernetes.allocation.batch.size': '512',
@@ -365,9 +365,9 @@ class TestGetSparkConf:
                     'spark.mesos.executor.memoryOverhead': '4096',
                 },
                 {
-                    'spark.executor.memory': '2g',
-                    'spark.executor.cores': '4',
-                    'spark.executor.instances': '3',
+                    'spark.executor.memory': '7g',
+                    'spark.executor.cores': '1',
+                    'spark.executor.instances': '1',
                     'spark.cores.max': '12',
                     'spark.kubernetes.executor.limit.cores': '4',
                     'spark.kubernetes.allocation.batch.size': '512',
@@ -383,7 +383,7 @@ class TestGetSparkConf:
                 {},
                 {
                     'spark.executor.memory': '28g',
-                    'spark.executor.cores': '2',
+                    'spark.executor.cores': '4',
                     'spark.cores.max': '4',
                 },
                 False,
@@ -397,13 +397,13 @@ class TestGetSparkConf:
                     'spark.cores.max': '12',
                 },
                 {
-                    'spark.executor.memory': '2g',
-                    'spark.executor.cores': '4',
+                    'spark.executor.memory': '7g',
+                    'spark.executor.cores': '1',
                     'spark.cores.max': '12',
                 },
                 False,
             ),
-            # user defined resources - recalculated
+            # user defined resources - recalculated - medium memory
             (
                 'mesos',
                 {
@@ -463,32 +463,51 @@ class TestGetSparkConf:
                 {
                     'spark.executor.cores': '4',
                     'spark.executor.memory': '32g',
-                    'spark.executor.instances': '1',
+                    'spark.executor.instances': '2',
                     'spark.cores.max': '32',
 
                 },
                 {
                     'spark.executor.cores': '4',
                     'spark.executor.memory': '28g',
-                    'spark.executor.instances': '1',
+                    'spark.executor.instances': '2',
                     'spark.cores.max': '32',
                 },
                 False,
             ),
-            # user defined resources - not recalculated
+            # user defined resources - recalculated - non standard memory
             (
                 'mesos',
                 {
-                    'spark.executor.cores': '4',
-                    'spark.executor.memory': '8g',
+                    'spark.executor.cores': '6',
+                    'spark.executor.memory': '13g',
                     'spark.executor.instances': '1',
                     'spark.cores.max': '32',
 
                 },
                 {
-                    'spark.executor.cores': '4',
-                    'spark.executor.memory': '8g',
+                    'spark.executor.cores': '1',
+                    'spark.executor.memory': '7g',
                     'spark.executor.instances': '1',
+                    'spark.cores.max': '32',
+                },
+                False,
+            ),
+            # user defined resources - recalculated - non standard memory - task cpus capped
+            (
+                'mesos',
+                {
+                    'spark.executor.cores': '6',
+                    'spark.executor.memory': '13g',
+                    'spark.executor.instances': '1',
+                    'spark.task.cpus': '4',
+                    'spark.cores.max': '32',
+                },
+                {
+                    'spark.executor.cores': '1',
+                    'spark.executor.memory': '7g',
+                    'spark.executor.instances': '1',
+                    'spark.task.cpus': '1',
                     'spark.cores.max': '32',
                 },
                 False,
@@ -537,8 +556,8 @@ class TestGetSparkConf:
                     'spark.mesos.gpus.max': '2',
                     'spark.mesos.containerizer': 'mesos',
                     'spark.default.parallelism': '2',
-                    'spark.task.cpus': '8',
-                    'spark.executor.cores': '8',
+                    'spark.task.cpus': '4',
+                    'spark.executor.cores': '4',
                     'spark.executor.memory': '28g',
                     'spark.cores.max': '16',
                 },


### PR DESCRIPTION
### Purpose of this PR
As indicated in MLCOMPUTE-533, this PR implemented the `Change Part-2`:  

Principles
1. Resources are determined based on memory requested by the user ("memory")
2. Keep memory:cpu = 7:1 to better fit aws instances
3. per_task_cpus = max(per_task_cpus, adjusted_executor_cpus)

Example:
- spark.executor.memory: 60GB, spark.executor.cores: 10, spark.executor.instances: 2
Total Current Memory: 60 * 2 = 120GB
- => Change to: spark.executor.memory: 56GB, spark.executor.cores: 8, spark.executor.instances: 2


### Testing
- Add unit tests
- Manually test run:  

1. Resources capped
```bash
paasta spark-run -s spark  --aws-credentials-yaml /etc/boto_cfg/mrjob.yaml --pool batch --spark-args "spark.executor.memory=200g spark.executor.cores=13 spark.executor.instances=2 spark.driver.memory=1g " --docker-memory-limit 1g --cmd "spark-submit /work/integration_tests/s3.py"
```
![image](https://user-images.githubusercontent.com/8851038/218785932-947f5c37-505c-4636-8862-eb6aaf8b609a.png)

2. Resources adjusted
```bash
paasta spark-run -s spark  --aws-credentials-yaml /etc/boto_cfg/mrjob.yaml --pool batch --spark-args "spark.executor.memory=6g spark.executor.cores=2 spark.executor.instances=2 spark.driver.memory=1g " --docker-memory-limit 1g --cmd "spark-submit /work/integration_tests/s3.py"
```
![image](https://user-images.githubusercontent.com/8851038/218784086-9691fea1-e800-4ace-bc79-2044b1e0b7e4.png)

DRA maxExecutors conf also overwritten:  
![image](https://user-images.githubusercontent.com/8851038/219080643-8f5e7774-62da-4914-b138-6c9578853199.png)

(with `--force-spark-resource-configs`)
![image](https://user-images.githubusercontent.com/8851038/219080615-d720ca8d-b86a-41a0-8c68-901490fbb246.png)

3. Not adjusted - already 7:1
```bash
paasta spark-run -s spark  --aws-credentials-yaml /etc/boto_cfg/mrjob.yaml --pool batch --spark-args "spark.executor.memory=7g spark.executor.cores=1 spark.executor.instances=1 spark.driver.memory=1g " --docker-memory-limit 1g --cmd "spark-submit /work/integration_tests/s3.py"
```
![image](https://user-images.githubusercontent.com/8851038/218785292-964e10b7-5292-4b2e-afc2-23d229cc9d5b.png)

4. Not adjusted - memory > multi-step release threshold 7g
```bash
paasta spark-run -s spark  --aws-credentials-yaml /etc/boto_cfg/mrjob.yaml --pool batch --spark-args "spark.executor.memory=28g spark.executor.cores=6 spark.executor.instances=1 spark.driver.memory=1g " --docker-memory-limit 1g --cmd "spark-submit /work/integration_tests/s3.py"
```
![image](https://user-images.githubusercontent.com/8851038/218785448-15593e5f-30ea-45d5-b70c-cb1e10f7ebdf.png)


### Additional Notes
There needs to be an announcement that we are making this change.  
