### PR TITLE
MLCOMPUTE-548 | enabled DRA by default for Jupyter Spark sessions

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -301,7 +301,7 @@ def get_dra_configs(spark_opts: Dict[str, str]) -> Dict[str, str]:
         f'the cached data was lost, please consider increasing this value.\n',
     )
 
-    min_ratio_executors = 0
+    min_ratio_executors = None
     if 'spark.dynamicAllocation.minExecutors' not in spark_opts:
         # the ratio of total executors to be used as minExecutors
         min_executor_ratio = spark_opts.get('spark.yelp.dra.minExecutorRatio', DEFAULT_DRA_MIN_EXECUTOR_RATIO)
@@ -364,7 +364,7 @@ def get_dra_configs(spark_opts: Dict[str, str]) -> Dict[str, str]:
 
     # TODO: add regex to better match Jupyterhub Spark session app name
     if 'jupyterhub' in spark_app_name and 'spark.dynamicAllocation.initialExecutors' not in spark_opts:
-        if min_ratio_executors:
+        if min_ratio_executors is not None:
             # set initialExecutors default equal to minimum executors calculated above using
             # 'spark.yelp.dra.minExecutorRatio' and DEFAULT_DRA_MIN_EXECUTOR_RATIO for Jupyter Spark sessions
             initial_executors = min_ratio_executors

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -275,7 +275,7 @@ def get_dra_configs(spark_opts: Dict[str, str]) -> Dict[str, str]:
     ):
         return spark_opts
 
-    spark_app_name = spark_opts.get('spark.app.name', "")
+    spark_app_name = spark_opts.get('spark.app.name', '')
     # set defaults if not provided already
     _append_spark_config(spark_opts, 'spark.dynamicAllocation.shuffleTracking.enabled', 'true')
     _append_spark_config(
@@ -320,7 +320,7 @@ def get_dra_configs(spark_opts: Dict[str, str]) -> Dict[str, str]:
             f'spark.dynamicAllocation.minExecutors in your spark args\n',
         )
 
-        if "jupyterhub" not in spark_app_name and 'spark.yelp.dra.minExecutorRatio' not in spark_opts:
+        if 'jupyterhub' not in spark_app_name and 'spark.yelp.dra.minExecutorRatio' not in spark_opts:
             log.debug(
                 f'\nspark.yelp.dra.minExecutorRatio not provided. This specifies the ratio of total executors '
                 f'to be used as minimum executors for Dynamic Resource Allocation. More info: y/spark-dra. Using '
@@ -914,7 +914,8 @@ def get_spark_conf(
         raise UnsupportedClusterManagerException(cluster_manager)
 
     # configure dynamic resource allocation configs
-    spark_conf = get_dra_configs(spark_conf)
+    if cluster_manager != 'mesos':
+        spark_conf = get_dra_configs(spark_conf)
 
     # configure spark_event_log
     spark_conf = _append_event_log_conf(spark_conf, *aws_creds)

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -275,6 +275,12 @@ def get_dra_configs(spark_opts: Dict[str, str]) -> Dict[str, str]:
     ):
         return spark_opts
 
+    log.warning(
+        'Spark Dynamic Resource Allocation (DRA) enabled for this batch. More info: y/spark-dra. '
+        'If your job is performing worse because of DRA, consider disabling DRA. To disable, '
+        'please provide spark.dynamicAllocation.enabled=false in your spark args\n',
+    )
+
     spark_app_name = spark_opts.get('spark.app.name', '')
     # set defaults if not provided already
     _append_spark_config(spark_opts, 'spark.dynamicAllocation.enabled', 'true')
@@ -291,7 +297,7 @@ def get_dra_configs(spark_opts: Dict[str, str]) -> Dict[str, str]:
         f'\nSetting spark.dynamicAllocation.cachedExecutorIdleTimeout as {DEFAULT_DRA_CACHED_EXECUTOR_IDLE_TIMEOUT}. '
         f'Executor with cached data block will be released if it has been idle for this duration. '
         f'If you wish to change the value of cachedExecutorIdleTimeout, please provide the exact value of '
-        f'spark.dynamicAllocation.cachedExecutorIdleTimeout in --spark-args. If your job is performing bad because '
+        f'spark.dynamicAllocation.cachedExecutorIdleTimeout in your spark args. If your job is performing bad because '
         f'the cached data was lost, please consider increasing this value.\n',
     )
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.13.5',
+    version='2.13.6',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -548,7 +548,7 @@ class TestGetSparkConf:
                     'spark.executor.instances': '606',
                 },
                 {
-                    'spark.executor.instances': '606',
+                    'spark.executor.instances': '151',  # enabled by default, 606/4
                 },
             ),
         ],
@@ -788,6 +788,20 @@ class TestGetSparkConf:
             'spark.executor.memory': '2g',
         }
         with MockConfigFunction('_adjust_spark_requested_resources', return_value) as m:
+            yield m
+
+    @pytest.fixture
+    def mock_get_dra_configs(self):
+        return_value = {
+            'spark.dynamicAllocation.enabled': 'true',
+            'spark.dynamicAllocation.maxExecutors': '2',
+            'spark.dynamicAllocation.shuffleTracking.enabled': 'true',
+            'spark.dynamicAllocation.executorAllocationRatio': '0.8',
+            'spark.executor.instances': '2',
+            'spark.dynamicAllocation.minExecutors': '0',
+            'spark.dynamicAllocation.cachedExecutorIdleTimeout': '900s',
+        }
+        with MockConfigFunction('get_dra_configs', return_value) as m:
             yield m
 
     @pytest.fixture
@@ -1114,6 +1128,7 @@ class TestGetSparkConf:
         mock_append_aws_credentials_conf,
         mock_append_sql_partitions_conf,
         mock_adjust_spark_requested_resources_kubernetes,
+        mock_get_dra_configs,
         mock_time,
         assert_ui_port,
         assert_app_name,
@@ -1150,6 +1165,7 @@ class TestGetSparkConf:
             assert_kubernetes_conf(output) +
             list(other_spark_opts.keys()) +
             list(mock_adjust_spark_requested_resources_kubernetes.return_value.keys()) +
+            list(mock_get_dra_configs.return_value.keys()) +
             list(mock_append_event_log_conf.return_value.keys()) +
             list(mock_append_aws_credentials_conf.return_value.keys()) +
             list(mock_append_sql_partitions_conf.return_value.keys()),
@@ -1201,6 +1217,7 @@ class TestGetSparkConf:
         mock_append_aws_credentials_conf,
         mock_append_sql_partitions_conf,
         mock_adjust_spark_requested_resources_kubernetes,
+        mock_get_dra_configs,
         mock_time,
         assert_ui_port,
         assert_app_name,
@@ -1229,6 +1246,7 @@ class TestGetSparkConf:
             assert_local_conf(output) +
             list(mock_append_event_log_conf.return_value.keys()) +
             list(mock_adjust_spark_requested_resources_kubernetes.return_value.keys()) +
+            list(mock_get_dra_configs.return_value.keys()) +
             list(mock_append_aws_credentials_conf.return_value.keys()) +
             list(mock_append_sql_partitions_conf.return_value.keys()),
         )


### PR DESCRIPTION
- Moved default enable DRA logic from `paasta spark-run` to here.
- Set `minExecutors` equal to 0 by default for Jupyter Spark sessions.
- Set `initialExecutors` equal to min executors calculated using DEFAULT_DRA_MIN_EXECUTOR_RATIO (1/4) for Jupyter Spark sessions