### PR TITLE
Release adjust spark executor resources for mem up to 14g

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -41,7 +41,7 @@ class ExecutorResourceConfig(NamedTuple):
 
 
 # Multi-step release - adjust if requested memory <= this threshold (memory in GB)
-ADJUST_EXECUTOR_MEM_CPU_RATIO_THRESH = 7
+ADJUST_EXECUTOR_MEM_CPU_RATIO_THRESH = 14
 
 RECOMMENDED_RESOURCE_CONFIGS: Dict[str, ExecutorResourceConfig] = {
     'recommended': ExecutorResourceConfig(4, 28),


### PR DESCRIPTION
Follow up release of #97.  

Tested via `paasta spark-run` in devbox.