### PR TITLE
Add ability to do an assume-role-with-web-identity call for spark

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -17,6 +17,7 @@ from typing import Tuple
 from urllib.parse import urlparse
 
 import boto3
+import botocore.exceptions
 import ephemeral_port_reserve
 import requests
 import yaml
@@ -125,6 +126,7 @@ def get_aws_credentials(
     profile_name: Optional[str] = None,
     session: Optional[boto3.Session] = None,
     aws_credentials_json: Optional[str] = None,
+    assume_web_identity: bool = False,
 ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
     """load aws creds using different method/file"""
     if no_aws_credentials:
@@ -135,6 +137,15 @@ def get_aws_credentials(
         with open(aws_credentials_json, 'r') as f:
             creds = json.load(f)
         return (creds.get('accessKeyId'), creds.get('secretAccessKey'), None)
+    elif assume_web_identity:
+        credentials = assume_aws_role_web_identity()
+        if credentials:
+            return (credentials['AccessKeyId'], credentials['SecretAccessKey'], credentials['SessionToken'])
+        else:
+            log.warning(
+                'Tried to assume role with web identity but either '
+                'AWS_WEB_IDENTITY_TOKEN_FILE or AWS_ROLE_ARN was not found',
+            )
     elif service != DEFAULT_SPARK_SERVICE:
         service_credentials_path = os.path.join(AWS_CREDENTIALS_DIR, f'{service}.yaml')
         if os.path.exists(service_credentials_path):
@@ -152,6 +163,36 @@ def get_aws_credentials(
         creds.secret_key,
         creds.token,
     )
+
+
+def assume_aws_role_web_identity():
+    """
+    Checks that a web identity token is available, and if it is,
+    get an aws session and return a credentials dictionary
+    """
+    if 'AWS_WEB_IDENTITY_TOKEN_FILE' not in os.environ or 'AWS_ROLE_ARN' not in os.environ:
+        return {}
+    with open(os.environ['AWS_WEB_IDENTITY_TOKEN_FILE']) as token_file:
+        token = token_file.read()
+    role_arn = os.environ['AWS_ROLE_ARN']
+    timestamp = int(time.time())
+    client = boto3.client('sts')
+    try:
+        resp = client.assume_role_with_web_identity(
+            RoleArn=role_arn,
+            RoleSessionName=f'SparkRun-{timestamp}',
+            WebIdentityToken=token,
+            DurationSeconds=43200,
+        )
+    except botocore.exceptions.ClientError:
+        resp = client.assume_role_with_web_identity(
+            RoleArn=role_arn,
+            RoleSessionName=f'SparkRun-{timestamp}',
+            WebIdentityToken=token,
+            DurationSeconds=3600,
+        )
+        log.warning(f"Session duration for {role_arn} is only 1 hour due to the role's maximum session duration")
+    return resp['Credentials']
 
 
 def _pick_random_port(app_name):

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -143,7 +143,7 @@ def get_aws_credentials(
             return (credentials['AccessKeyId'], credentials['SecretAccessKey'], credentials['SessionToken'])
         else:
             log.warning(
-                'Tried to assume role with web identity but either '
+                'Tried to assume role with web identity but neither '
                 'AWS_WEB_IDENTITY_TOKEN_FILE or AWS_ROLE_ARN was not found',
             )
     elif service != DEFAULT_SPARK_SERVICE:


### PR DESCRIPTION
This adds a new method to getting aws credentials, web identity. Web identity is used with kubernetes pod identity in particular, and this change will allow us to have paasta spark-run get a session and pass those credentials to the spark job.

This functionality depends on two environment variables being set, and if either is missing, it will emit a warning and then continue with the default boto3 session. It will also attempt to use the maximum 12 hours session but fall back to 1 hour with a warning, as the 12 hour maximum must be set in AWS for each role, 1 hour being the default max. Any other error will be raised. 

Added a unit test as well as performed some manual testing:
```
$ env | grep AWS
AWS_WEB_IDENTITY_TOKEN_FILE=/nail/home/qlo/token
AWS_ROLE_ARN=arn:aws:iam::528****:role/service_*****
$ python
>>> from service_configuration_lib import spark_config
>>> creds = spark_config.get_aws_credentials(assume_web_identity=True)
Session duration for arn:aws:iam::528****:role/service_*** is only 1 hour due to the role's maximum session duration
>>> creds
('ASIAXW****', 'TmZG****', 'FwoG*****')
```