### PR TITLE
Remove showConsole flag

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1229,7 +1229,8 @@ def get_spark_conf(
     spark_conf = _append_spark_config(spark_conf, 'spark.logConf', 'true')
 
     # configure spark Console Progress
-    spark_conf = _append_spark_config(spark_conf, 'spark.ui.showConsoleProgress', 'true')
+    if _is_jupyterhub_job(spark_conf.get('spark.app.name', '')):
+        spark_conf = _append_spark_config(spark_conf, 'spark.ui.showConsoleProgress', 'true')
 
     spark_conf = _append_aws_credentials_conf(spark_conf, *aws_creds, aws_region)
     return spark_conf

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1228,9 +1228,6 @@ def get_spark_conf(
     # configure spark conf log
     spark_conf = _append_spark_config(spark_conf, 'spark.logConf', 'true')
 
-    # configure spark Console Progress
-    spark_conf = _append_spark_config(spark_conf, 'spark.ui.showConsoleProgress', 'true')
-
     spark_conf = _append_aws_credentials_conf(spark_conf, *aws_creds, aws_region)
     return spark_conf
 

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1228,6 +1228,9 @@ def get_spark_conf(
     # configure spark conf log
     spark_conf = _append_spark_config(spark_conf, 'spark.logConf', 'true')
 
+    # configure spark Console Progress
+    spark_conf = _append_spark_config(spark_conf, 'spark.ui.showConsoleProgress', 'true')
+
     spark_conf = _append_aws_credentials_conf(spark_conf, *aws_creds, aws_region)
     return spark_conf
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.16.0',
+    version='2.16.1',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -949,22 +949,6 @@ class TestGetSparkConf:
 
         assert output[key] == expected_output
 
-    @pytest.mark.parametrize(
-        'user_spark_opts,expected_output', [
-            # not configured by user
-            ({}, 'true'),
-            # configured by user
-            ({'spark.ui.showConsoleProgress': 'false'}, 'false'),
-        ],
-    )
-    def test_append_console_progress_conf(
-            self, user_spark_opts, expected_output,
-    ):
-        key = 'spark.ui.showConsoleProgress'
-        output = spark_config._append_spark_config(user_spark_opts, key, 'true')
-
-        assert output[key] == expected_output
-
     def test_append_aws_credentials_conf(self):
         output = spark_config._append_aws_credentials_conf(
             {},
@@ -979,14 +963,6 @@ class TestGetSparkConf:
     @pytest.fixture
     def mock_append_spark_conf_log(self):
         return_value = {'spark.logConf': 'true'}
-        with MockConfigFunction(
-                '_append_spark_config', return_value,
-        ) as m:
-            yield m
-
-    @pytest.fixture
-    def mock_append_console_progress_conf(self):
-        return_value = {'spark.ui.showConsoleProgress': 'true'}
         with MockConfigFunction(
                 '_append_spark_config', return_value,
         ) as m:
@@ -1272,7 +1248,6 @@ class TestGetSparkConf:
             'spark.kubernetes.executor.label.paasta.yelp.com/pool': self.pool,
             'spark.kubernetes.executor.label.yelp.com/owner': 'core_ml',
             'spark.logConf': 'true',
-            'spark.ui.showConsoleProgress': 'true',
         }
         for i, volume in enumerate(base_volumes + self._get_k8s_base_volumes()):
             expected_output[f'spark.kubernetes.executor.volumes.hostPath.{i}.mount.path'] = volume['containerPath']
@@ -1362,7 +1337,6 @@ class TestGetSparkConf:
             'spark.executorEnv.PAASTA_INSTANCE_TYPE': 'spark',
             'spark.executorEnv.SPARK_EXECUTOR_DIRS': '/tmp',
             'spark.logConf': 'true',
-            'spark.ui.showConsoleProgress': 'true',
         }
         for i, volume in enumerate(base_volumes + self._get_k8s_base_volumes()):
             expected_output[f'spark.kubernetes.executor.volumes.hostPath.{i}.mount.path'] = volume['containerPath']


### PR DESCRIPTION
This flag would show the live progress of a spark job on the console (driver logs).
This is really useful for debugging.
However, as part of tron jobs it is noisy, and not useful to parse for debugging purposes.
This can be added on-demand as part of adhoc jobs.

Testing: Unit tests.
