### PR TITLE
MLCOMPUTE-707 | fix unreadable formatting in costs log

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1076,16 +1076,16 @@ def compute_approx_hourly_cost_dollars(spark_conf, paasta_cluster, paasta_pool):
                 TextColors.bold(
                     f'\nThe requested resources are expected to cost a maximum of $ {str(max_dollars)} '
                     f'every hour and $ {str(max_dollars * 24)} in a day.\n',
-                )
+                ),
             ),
         )
     else:
         log.warning(
             TextColors.magenta(
                 TextColors.bold(
-                    f'\nThe requested resources are expected to cost $ {max_dollars} every hour and $ {max_dollars * 24} '
-                    f'in a day.\n',
-                )
+                    f'\nThe requested resources are expected to cost $ {max_dollars} every hour and '
+                    f'$ {max_dollars * 24} in a day.\n',
+                ),
             ),
         )
     return min_dollars, max_dollars

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1070,24 +1070,16 @@ def compute_approx_hourly_cost_dollars(spark_conf, paasta_cluster, paasta_pool):
                 ),
             ),
         )
-    if min_dollars != max_dollars:
-        log.warning(
-            TextColors.magenta(
-                TextColors.bold(
-                    f'\nThe requested resources are expected to cost a maximum of $ {str(max_dollars)} '
-                    f'every hour and $ {str(max_dollars * 24)} in a day.\n',
-                ),
+    log.warning(
+        TextColors.magenta(
+            TextColors.bold(
+                f'\nExpected {"maximum" if min_dollars != max_dollars else ""} cost based on requested resources: '
+                f'${str(max_dollars)} every hour and ${str(max_dollars * 24)} in a day.'
+                f'\nPlease monitor y/spark-metrics for memory and cpu usage to tune requested executor count'
+                f' config spark.executor.instances.\nFollow y/write-spark-job for optimization tips.\n',
             ),
-        )
-    else:
-        log.warning(
-            TextColors.magenta(
-                TextColors.bold(
-                    f'\nThe requested resources are expected to cost $ {max_dollars} every hour and '
-                    f'$ {max_dollars * 24} in a day.\n',
-                ),
-            ),
-        )
+        ),
+    )
     return min_dollars, max_dollars
 
 

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1073,15 +1073,19 @@ def compute_approx_hourly_cost_dollars(spark_conf, paasta_cluster, paasta_pool):
     if min_dollars != max_dollars:
         log.warning(
             TextColors.magenta(
-                f'\nThe requested resources are expected to cost a maximum of $ {TextColors.bold(str(max_dollars))} '
-                f'every hour and $ {TextColors.bold(str(max_dollars * 24))} in a day.\n',
+                TextColors.bold(
+                    f'\nThe requested resources are expected to cost a maximum of $ {str(max_dollars)} '
+                    f'every hour and $ {str(max_dollars * 24)} in a day.\n',
+                )
             ),
         )
     else:
         log.warning(
             TextColors.magenta(
-                f'\nThe requested resources are expected to cost $ {max_dollars} every hour and $ {max_dollars * 24} '
-                f'in a day.\n',
+                TextColors.bold(
+                    f'\nThe requested resources are expected to cost $ {max_dollars} every hour and $ {max_dollars * 24} '
+                    f'in a day.\n',
+                )
             ),
         )
     return min_dollars, max_dollars


### PR DESCRIPTION
Fix unreadable cost log in tron logs

Testing:
With DRA enabled:
<img width="894" alt="image" src="https://user-images.githubusercontent.com/30409342/230378439-0b42e42e-12aa-46ba-a446-8761e727c23b.png">

With DRA disabled:
<img width="897" alt="image" src="https://user-images.githubusercontent.com/30409342/230378636-b613c755-a7c0-4ff7-8428-edf477b1dd4b.png">
