### PR TITLE
Change assume_aws_role to use user credentials rather than  web identity token

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -172,9 +172,9 @@ def get_aws_credentials(
 
 
 def assume_aws_role(
-    role_arn,
-    session_duration,
-    key_file,
+    role_arn: str,
+    session_duration: int,
+    key_file: str,
 ) -> Dict[str, str]:
     """
     Checks that a web identity token is available, and if it is,


### PR DESCRIPTION
The code that I'm modifying was added in #105 but after that, I realized that spark-run doesn't happen in the context of a k8s pod. That means this code is currently unused and changing behavior will not break anything.

I decided to try to switch this to using a static credentials on the host rather than a web identity token file. The code is roughly the same, just with that key difference. When paired with a change to paasta, I was able to verify this:

```
$ paasta spark-run --service spark --cluster pnw-devc --pool batch --assume-aws-role arn:aws:iam::52xxxxx:role/spark_test_role -C 'aws sts get-caller-identity'
...
Selected cluster manager: kubernetes

Setting docker memory and cpu limits as 2g, 1 core(s) respectively.
{
    "UserId": "AROAXXXXX:SparkRun-1680651893",
    "Account": "52xxxxx",
    "Arn": "arn:aws:sts::52xxxxx:assumed-role/spark_test_role/SparkRun-1680651893"
}
```

See also https://github.com/Yelp/paasta/pull/3584