### PR TITLE
MLCOMPUTE-699 | Mandatory spark srv config defaults

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -86,7 +86,7 @@ mandatory_default_spark_srv_conf = dict()
 spark_costs = dict()
 
 
-def _load_spark_srv_conf(preset_values: Dict[str, Any] = None):
+def _load_spark_srv_conf(preset_values=None):
     if preset_values is None:
         preset_values = dict()
     global spark_srv_conf, spark_constants, default_spark_srv_conf, mandatory_default_spark_srv_conf, spark_costs
@@ -967,7 +967,7 @@ def update_spark_srv_configs(spark_conf: MutableMapping[str, str]):
 def compute_approx_hourly_cost_dollars(
         spark_conf: Mapping[str, str],
         paasta_cluster: str,
-        paasta_pool: str
+        paasta_pool: str,
 ) -> Tuple[float, float]:
     per_executor_cores = int(spark_conf.get(
         'spark.executor.cores',

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -299,7 +299,7 @@ def _append_sql_partitions_conf(spark_opts: Dict[str, str]) -> Dict[str, str]:
             str(spark_opts['spark.dynamicAllocation.maxExecutors']) != 'infinity'
         ):
 
-            num_partitions_dra = (
+            num_partitions_dra = 3 * (
                 int(spark_opts.get('spark.dynamicAllocation.maxExecutors', 0)) *
                 int(spark_opts.get('spark.executor.cores', default_spark_srv_conf.get('spark.executor.cores', 4)))
             )
@@ -308,7 +308,7 @@ def _append_sql_partitions_conf(spark_opts: Dict[str, str]) -> Dict[str, str]:
         num_partitions = num_partitions or default_spark_srv_conf.get('spark.sql.shuffle.partitions', 128)
         _append_spark_config(spark_opts, 'spark.sql.shuffle.partitions', str(num_partitions))
     else:
-        num_partitions = spark_opts['spark.sql.shuffle.partitions']
+        num_partitions = int(spark_opts['spark.sql.shuffle.partitions'])
     _append_spark_config(spark_opts, 'spark.sql.files.minPartitionNum', str(num_partitions))
     _append_spark_config(spark_opts, 'spark.default.parallelism', str(num_partitions))
 
@@ -343,7 +343,9 @@ def get_dra_configs(spark_opts: Dict[str, str]) -> Dict[str, str]:
         spark_opts, 'spark.dynamicAllocation.executorAllocationRatio',
         str(default_spark_srv_conf.get('spark.dynamicAllocation.executorAllocationRatio', 0.8)),
     )
-    cached_executor_idle_timeout = default_spark_srv_conf.get('spark.dynamicAllocation.cachedExecutorIdleTimeout', '1500s')
+    cached_executor_idle_timeout = default_spark_srv_conf.get(
+        'spark.dynamicAllocation.cachedExecutorIdleTimeout', '1500s',
+    )
     if 'spark.dynamicAllocation.cachedExecutorIdleTimeout' not in spark_opts:
         if _is_jupyterhub_job(spark_app_name):
             # increase cachedExecutorIdleTimeout by 15 minutes in case of Jupyterhub

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -77,8 +77,10 @@ SUPPORTED_CLUSTER_MANAGERS = ['kubernetes', 'local']
 log = logging.Logger(__name__)
 log.setLevel(logging.INFO)
 
-(spark_srv_conf, spark_constants, default_spark_srv_conf,
- mandatory_default_spark_srv_conf, spark_costs) = load_spark_srv_conf()
+(
+    spark_srv_conf, spark_constants, default_spark_srv_conf,
+    mandatory_default_spark_srv_conf, spark_costs,
+) = load_spark_srv_conf()
 
 
 class UnsupportedClusterManagerException(Exception):

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -23,13 +23,13 @@ import yaml
 from boto3 import Session
 
 from service_configuration_lib.text_colors import TextColors
+from service_configuration_lib.utils import load_spark_srv_conf
 
 AWS_CREDENTIALS_DIR = '/etc/boto_cfg/'
 AWS_ENV_CREDENTIALS_PROVIDER = 'com.amazonaws.auth.EnvironmentVariableCredentialsProvider'
 GPU_POOLS_YAML_FILE_PATH = '/nail/srv/configs/gpu_pools.yaml'
 DEFAULT_PAASTA_VOLUME_PATH = '/etc/paasta/volumes.json'
 DEFAULT_SPARK_MESOS_SECRET_FILE = '/nail/etc/paasta_spark_secret'
-DEFAULT_SPARK_RUN_CONFIG = '/nail/srv/configs/spark.yaml'
 DEFAULT_SPARK_SERVICE = 'spark'
 GPUS_HARD_LIMIT = 15
 CLUSTERMAN_METRICS_YAML_FILE_PATH = '/nail/srv/configs/clusterman_metrics.yaml'
@@ -77,33 +77,8 @@ SUPPORTED_CLUSTER_MANAGERS = ['kubernetes', 'local']
 log = logging.Logger(__name__)
 log.setLevel(logging.INFO)
 
-
-# Spark srv-configs
-spark_srv_conf = dict()
-spark_constants = dict()
-default_spark_srv_conf = dict()
-mandatory_default_spark_srv_conf = dict()
-spark_costs = dict()
-
-
-def _load_spark_srv_conf(preset_values=None):
-    if preset_values is None:
-        preset_values = dict()
-    global spark_srv_conf, spark_constants, default_spark_srv_conf, mandatory_default_spark_srv_conf, spark_costs
-    try:
-        with open(DEFAULT_SPARK_RUN_CONFIG) as fp:
-            loaded_values = yaml.safe_load(fp.read())
-            spark_srv_conf = {**preset_values, **loaded_values}
-            spark_constants = spark_srv_conf.get('spark_constants', dict())
-            default_spark_srv_conf = spark_constants.get('defaults', dict())
-            mandatory_default_spark_srv_conf = spark_constants.get('mandatory_defaults', dict())
-            spark_costs = spark_constants.get('cost_factor', dict())
-    except Exception as e:
-        log.warning(f'Failed to load {DEFAULT_SPARK_RUN_CONFIG}: {e}')
-        raise e
-
-
-_load_spark_srv_conf()
+(spark_srv_conf, spark_constants, default_spark_srv_conf,
+ mandatory_default_spark_srv_conf, spark_costs) = load_spark_srv_conf()
 
 
 class UnsupportedClusterManagerException(Exception):

--- a/service_configuration_lib/utils.py
+++ b/service_configuration_lib/utils.py
@@ -1,4 +1,6 @@
 import logging
+from typing import Mapping
+from typing import Tuple
 
 import yaml
 
@@ -8,7 +10,7 @@ log = logging.Logger(__name__)
 log.setLevel(logging.INFO)
 
 
-def load_spark_srv_conf(preset_values=None):
+def load_spark_srv_conf(preset_values=None) -> Tuple[Mapping, Mapping, Mapping, Mapping, Mapping]:
     if preset_values is None:
         preset_values = dict()
     try:

--- a/service_configuration_lib/utils.py
+++ b/service_configuration_lib/utils.py
@@ -1,4 +1,5 @@
 import logging
+
 import yaml
 
 DEFAULT_SPARK_RUN_CONFIG = '/nail/srv/configs/spark.yaml'
@@ -20,7 +21,7 @@ def load_spark_srv_conf(preset_values=None):
             spark_costs = spark_constants['cost_factor']
             return (
                 spark_srv_conf, spark_constants, default_spark_srv_conf,
-                mandatory_default_spark_srv_conf, spark_costs
+                mandatory_default_spark_srv_conf, spark_costs,
             )
     except Exception as e:
         log.warning(f'Failed to load {DEFAULT_SPARK_RUN_CONFIG}: {e}')

--- a/service_configuration_lib/utils.py
+++ b/service_configuration_lib/utils.py
@@ -18,7 +18,10 @@ def load_spark_srv_conf(preset_values=None):
             default_spark_srv_conf = spark_constants['defaults']
             mandatory_default_spark_srv_conf = spark_constants['mandatory_defaults']
             spark_costs = spark_constants['cost_factor']
-            return spark_srv_conf, spark_constants, default_spark_srv_conf, mandatory_default_spark_srv_conf, spark_costs
+            return (
+                spark_srv_conf, spark_constants, default_spark_srv_conf,
+                mandatory_default_spark_srv_conf, spark_costs
+            )
     except Exception as e:
         log.warning(f'Failed to load {DEFAULT_SPARK_RUN_CONFIG}: {e}')
         raise e

--- a/service_configuration_lib/utils.py
+++ b/service_configuration_lib/utils.py
@@ -1,0 +1,24 @@
+import logging
+import yaml
+
+DEFAULT_SPARK_RUN_CONFIG = '/nail/srv/configs/spark.yaml'
+
+log = logging.Logger(__name__)
+log.setLevel(logging.INFO)
+
+
+def load_spark_srv_conf(preset_values=None):
+    if preset_values is None:
+        preset_values = dict()
+    try:
+        with open(DEFAULT_SPARK_RUN_CONFIG, 'r') as fp:
+            loaded_values = yaml.safe_load(fp.read())
+            spark_srv_conf = {**preset_values, **loaded_values}
+            spark_constants = spark_srv_conf['spark_constants']
+            default_spark_srv_conf = spark_constants['defaults']
+            mandatory_default_spark_srv_conf = spark_constants['mandatory_defaults']
+            spark_costs = spark_constants['cost_factor']
+            return spark_srv_conf, spark_constants, default_spark_srv_conf, mandatory_default_spark_srv_conf, spark_costs
+    except Exception as e:
+        log.warning(f'Failed to load {DEFAULT_SPARK_RUN_CONFIG}: {e}')
+        raise e

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.17.0',
+    version='2.17.1',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -69,7 +69,7 @@ spark_run_conf = {
     },
 }
 mp = MonkeyPatch()
-with open('spark_run.yaml', 'w+') as fp:
+with open('tmp_spark_srv_config.yaml', 'w+') as fp:
     fp.write(yaml.dump(spark_run_conf))
     mp.setattr(utils, 'DEFAULT_SPARK_RUN_CONFIG', os.path.abspath(fp.name))
 
@@ -1776,3 +1776,6 @@ def test_send_and_calculate_resources_cost(
 )
 def test_get_k8s_resource_name_limit_size_with_hash(instance_name, expected_instance_label):
     assert expected_instance_label == spark_config._get_k8s_resource_name_limit_size_with_hash(instance_name)
+
+
+os.remove('tmp_spark_srv_config.yaml')

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -8,9 +8,9 @@ from unittest import mock
 import pytest
 import requests
 import yaml
-from service_configuration_lib import utils
-
 from pytest import MonkeyPatch
+
+from service_configuration_lib import utils
 
 TEST_ACCOUNT_ID = '123456789'
 
@@ -73,7 +73,7 @@ with open('spark_run.yaml', 'w+') as fp:
     fp.write(yaml.dump(spark_run_conf))
     mp.setattr(utils, 'DEFAULT_SPARK_RUN_CONFIG', os.path.abspath(fp.name))
 
-from service_configuration_lib import spark_config  # noreorder
+from service_configuration_lib import spark_config  # noqa
 
 
 @pytest.fixture

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -32,6 +32,39 @@ def mock_spark_run_conf(tmpdir, monkeypatch):
                 'history_server': 'https://spark-history-testing',
             },
         },
+        'spark_constants': {
+            'target_mem_cpu_ratio': 7,
+            'defaults': {
+                'spark.executor.cores': 4,
+                'spark.executor.instances': 2,
+                'spark.executor.memory': 28,
+                'spark.task.cpus': 1,
+                'spark.sql.shuffle.partitions': 128,
+                'spark.dynamicAllocation.executorAllocationRatio': 0.8,
+                'spark.dynamicAllocation.cachedExecutorIdleTimeout': '1500s',
+                'spark.yelp.dra.minExecutorRatio': 0.25,
+            },
+            'resource_configs': {
+                'recommended': {
+                    'cpu': 4,
+                    'mem': 28,
+                },
+                'medium': {
+                    'cpu': 8,
+                    'mem': 56,
+                },
+                'max': {
+                    'cpu': 12,
+                    'mem': 110,
+                },
+            },
+            'cost_factor': {
+                'test-cluster': {
+                    'test-pool': 100,
+                },
+            },
+            'high_cost_threshold_daily': 500,
+        },
     }
     fp = tmpdir.join('spark_run.yaml')
     fp.write(yaml.dump(spark_run_conf))

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -65,7 +65,7 @@ spark_run_conf = {
             'spark.kubernetes.allocation.batch.size': 512,
             'spark.kubernetes.decommission.script': '/opt/spark/kubernetes/dockerfiles/spark/decom.sh',
             'spark.logConf': 'true',
-        }
+        },
     },
 }
 mp = MonkeyPatch()
@@ -73,7 +73,7 @@ with open('spark_run.yaml', 'w+') as fp:
     fp.write(yaml.dump(spark_run_conf))
     mp.setattr(utils, 'DEFAULT_SPARK_RUN_CONFIG', os.path.abspath(fp.name))
 
-from service_configuration_lib import spark_config
+from service_configuration_lib import spark_config  # noreorder
 
 
 @pytest.fixture


### PR DESCRIPTION
- Added mandatory spark srv config defaults
- Deprecated mesos usage
- Fix spark.executor.cores default
- Better code formatting