### PR TITLE
Fix service_configuration_lib dependency conflict bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 importlib-resources==5.4.0
 pyinotify==0.9.6
 pyyaml >= 3.0
+# To resolve the error: botocore 1.29.125 has requirement urllib3<1.27,>=1.25.4, but you'll have urllib3 2.0.1 which is incompatible.
 urllib3==1.26.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 importlib-resources==5.4.0
 pyinotify==0.9.6
 pyyaml >= 3.0
+urllib3==1.26.15

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.16.1',
+    version='2.16.2',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',


### PR DESCRIPTION
Issue: https://github.com/Yelp/service_configuration_lib/actions/runs/4873917098/jobs/8694615557

Alternate solution: Upgrade botocore to newer version. 

Tests: Unit tests

Adding @luisp for visibility. I couldn't find Jon Lee's github user-id. 
