### PR TITLE
Enable prometheus metrics export on driver's endpoint

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -447,6 +447,13 @@ def get_dra_configs(spark_opts: Dict[str, str]) -> Dict[str, str]:
     return spark_opts
 
 
+def _append_spark_prometheus_conf(spark_opts: Dict[str, str]) -> Dict[str, str]:
+    spark_opts['spark.ui.prometheus.enabled'] = 'true'
+    spark_opts['spark.metrics.conf.*.sink.prometheusServlet.class'] = 'org.apache.spark.metrics.sink.PrometheusServlet'
+    spark_opts['spark.metrics.conf.*.sink.prometheusServlet.path'] = '/metrics/prometheus'
+    return spark_opts
+
+
 def _append_event_log_conf(
     spark_opts: Dict[str, str],
     access_key: Optional[str],
@@ -1229,6 +1236,9 @@ def get_spark_conf(
 
     # generate cost warnings
     compute_approx_hourly_cost_dollars(spark_conf, paasta_cluster, paasta_pool)
+
+    # configure spark prometheus metrics
+    spark_conf = _append_spark_prometheus_conf(spark_conf)
 
     # configure spark_event_log
     spark_conf = _append_event_log_conf(spark_conf, *aws_creds)

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -977,6 +977,19 @@ class TestGetSparkConf:
         assert output['spark.executorEnv.AWS_SESSION_TOKEN'] == mock.sentinel.token
 
     @pytest.fixture
+    def mock_append_spark_prometheus_conf(self):
+        return_value = {
+            'spark.ui.prometheus.enabled': 'true',
+            'spark.metrics.conf.*.sink.prometheusServlet.class': 'org.apache.spark.metrics.sink.PrometheusServlet',
+            'spark.metrics.conf.*.sink.prometheusServlet.path': '/metrics/prometheus',
+        }
+
+        with MockConfigFunction(
+            '_append_spark_prometheus_conf', return_value,
+        ) as m:
+            yield m
+
+    @pytest.fixture
     def mock_append_spark_conf_log(self):
         return_value = {'spark.logConf': 'true'}
         with MockConfigFunction(
@@ -1283,6 +1296,7 @@ class TestGetSparkConf:
         spark_opts_from_env,
         ui_port,
         base_volumes,
+        mock_append_spark_prometheus_conf,
         mock_append_event_log_conf,
         mock_append_aws_credentials_conf,
         mock_append_sql_partitions_conf,
@@ -1326,6 +1340,7 @@ class TestGetSparkConf:
             list(other_spark_opts.keys()) +
             list(mock_adjust_spark_requested_resources_kubernetes.return_value.keys()) +
             list(mock_get_dra_configs.return_value.keys()) +
+            list(mock_append_spark_prometheus_conf.return_value.keys()) +
             list(mock_append_event_log_conf.return_value.keys()) +
             list(mock_append_aws_credentials_conf.return_value.keys()) +
             list(mock_append_sql_partitions_conf.return_value.keys()),
@@ -1408,6 +1423,7 @@ class TestGetSparkConf:
         spark_opts_from_env,
         ui_port,
         base_volumes,
+        mock_append_spark_prometheus_conf,
         mock_append_event_log_conf,
         mock_append_aws_credentials_conf,
         mock_append_sql_partitions_conf,
@@ -1440,6 +1456,7 @@ class TestGetSparkConf:
             assert_ui_port(output) +
             assert_app_name(output) +
             assert_local_conf(output) +
+            list(mock_append_spark_prometheus_conf.return_value.keys()) +
             list(mock_append_event_log_conf.return_value.keys()) +
             list(mock_adjust_spark_requested_resources_kubernetes.return_value.keys()) +
             list(mock_get_dra_configs.return_value.keys()) +


### PR DESCRIPTION
### Description
Add default spark configs to enable metrics exporting for Prometheus on the driver's endpoint.

### Test
Run with paasta spark-run in the devbox, check if the below 2 URLs are working:  
* http://<devbox_host>:45523/metrics/prometheus/
* http://<devbox_host>:45523/metrics/executors/prometheus/
