### PR TITLE
Disable decommission for non-spot pools

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1109,6 +1109,10 @@ class SparkConfBuilder:
         else:
             raise UnsupportedClusterManagerException(cluster_manager)
 
+        # Enabling auto-decommission feature to move data around makes sense for only spot nodes
+        if 'batch' != paasta_pool and 'spark.decommission.enabled' in spark_conf:
+            spark_conf.update({'spark.decommission.enabled': 'false'})
+
         # configure dynamic resource allocation configs
         spark_conf = self.get_dra_configs(spark_conf)
 


### PR DESCRIPTION
Decommission feature makes sense only for spot pools.
There have been issues seen in the past for on-demand pools where the spark executors were running for long-time even if there are no active tasks, leading to hanging jobs

This has potentially been linked to decommission feature.

There shouldn't be any downside of disabling this feature for non-spot pools. 