### PR TITLE
Setting spark.app.id to a more intuitive name

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -37,6 +37,7 @@ CLUSTERMAN_YAML_FILE_PATH = '/nail/srv/configs/clusterman.yaml'
 
 NON_CONFIGURABLE_SPARK_OPTS = {
     'spark.master',
+    'spark.app.id',
     'spark.ui.port',
     'spark.mesos.principal',
     'spark.mesos.secret',
@@ -1076,6 +1077,11 @@ class SparkConfBuilder:
             _pick_random_port(PREFERRED_SPARK_UI_PORT),
         )
 
+        spark_conf = {**(spark_opts_from_env or {}), **_filter_user_spark_opts(user_spark_opts)}
+
+        if aws_creds[2] is not None:
+            spark_conf['spark.hadoop.fs.s3a.aws.credentials.provider'] = AWS_ENV_CREDENTIALS_PROVIDER
+
         # app_name from env is already appended port and time to make it unique
         app_name = (spark_opts_from_env or {}).get('spark.app.name')
         if not app_name:
@@ -1083,13 +1089,14 @@ class SparkConfBuilder:
             # from history server.
             app_name = f'{app_base_name}_{ui_port}_{int(time.time())}'
 
-        spark_conf = {**(spark_opts_from_env or {}), **_filter_user_spark_opts(user_spark_opts)}
-
-        if aws_creds[2] is not None:
-            spark_conf['spark.hadoop.fs.s3a.aws.credentials.provider'] = AWS_ENV_CREDENTIALS_PROVIDER
+        # Explicitly setting app id: replace '-' to '_' to make it consistent in all places for metric systems:
+        # - since the Spark app id in Promehteus metrics will be converted to underscores,
+        # - while the 'spark-app-selector' executor pod label will keep the original app id.
+        app_id = app_name.replace('-', '_')
 
         spark_conf.update({
             'spark.app.name': app_name,
+            'spark.app.id': app_id,
             'spark.ui.port': str(ui_port),
         })
 

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -6,6 +6,7 @@ import json
 import logging
 import math
 import os
+import re
 import time
 from typing import Any
 from typing import Dict
@@ -1089,10 +1090,11 @@ class SparkConfBuilder:
             # from history server.
             app_name = f'{app_base_name}_{ui_port}_{int(time.time())}'
 
-        # Explicitly setting app id: replace '-' to '_' to make it consistent in all places for metric systems:
-        # - since the Spark app id in Promehteus metrics will be converted to underscores,
-        # - while the 'spark-app-selector' executor pod label will keep the original app id.
-        app_id = app_name.replace('-', '_')
+        # Explicitly setting app id: replace special characters to '_' to make it consistent
+        # in all places for metric systems:
+        # - since in the Promehteus metrics endpoint those will be converted to '_'
+        # - while the 'spark-app-selector' executor pod label will keep the original app id
+        app_id = re.sub(r'[\.,-]', '_', app_name)
 
         spark_conf.update({
             'spark.app.name': app_name,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.18.3',
+    version='2.18.4',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -1139,6 +1139,14 @@ class TestGetSparkConf:
         return verify
 
     @pytest.fixture
+    def assert_app_id(self):
+        def verify(output):
+            key = 'spark.app.id'
+            assert output[key] == output['spark.app.name'].replace('-', '_')
+            return [key]
+        return verify
+
+    @pytest.fixture
     def assert_mesos_conf(self):
         def verify(output):
             expected_output = {
@@ -1230,6 +1238,7 @@ class TestGetSparkConf:
         mock_time,
         assert_ui_port,
         assert_app_name,
+        assert_app_id,
         assert_kubernetes_conf,
         mock_log,
     ):
@@ -1262,6 +1271,7 @@ class TestGetSparkConf:
         verified_keys = set(
             assert_ui_port(output) +
             assert_app_name(output) +
+            assert_app_id(output) +
             assert_kubernetes_conf(output) +
             list(other_spark_opts.keys()) +
             list(mock_adjust_spark_requested_resources_kubernetes.return_value.keys()) +
@@ -1321,6 +1331,7 @@ class TestGetSparkConf:
         mock_time,
         assert_ui_port,
         assert_app_name,
+        assert_app_id,
         assert_local_conf,
         mock_log,
     ):
@@ -1361,6 +1372,7 @@ class TestGetSparkConf:
         mock_time,
         assert_ui_port,
         assert_app_name,
+        assert_app_id,
         assert_local_conf,
         mock_log,
     ):
@@ -1385,6 +1397,7 @@ class TestGetSparkConf:
         verified_keys = set(
             assert_ui_port(output) +
             assert_app_name(output) +
+            assert_app_id(output) +
             assert_local_conf(output) +
             list(mock_append_spark_prometheus_conf.return_value.keys()) +
             list(mock_append_event_log_conf.return_value.keys()) +

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -2,6 +2,7 @@ import functools
 import itertools
 import json
 import os
+import re
 import sys
 from unittest import mock
 
@@ -1142,7 +1143,7 @@ class TestGetSparkConf:
     def assert_app_id(self):
         def verify(output):
             key = 'spark.app.id'
-            assert output[key] == output['spark.app.name'].replace('-', '_')
+            assert output[key] == re.sub(r'[\.,-]', '_', output['spark.app.name'])
             return [key]
         return verify
 


### PR DESCRIPTION
1. Setting spark app id to same as the spark app name
2. Replacing `-`, `.`, `,` characters to `_` for app id

Test: test starting a new spark session and call the Spark's API at `http://<driver_ip>:<ui_port>/api/v1/applications`:  
```
[ {
  "id" : "jupyterhub_chi_test_spark_39091_1692232285",
  "name" : "jupyterhub_chi_test-spark_39091_1692232285",
  "attempts" : [ {
    "startTime" : "2023-08-17T00:31:28.283GMT",
    "endTime" : "1969-12-31T23:59:59.999GMT",
    "lastUpdated" : "2023-08-17T00:31:28.283GMT",
    "duration" : 1038136,
    "sparkUser" : "chi",
    "completed" : false,
    "appSparkVersion" : "3.2.4",
    "startTimeEpoch" : 1692232288283,
    "endTimeEpoch" : -1,
    "lastUpdatedEpoch" : 1692232288283
  } ]
} ]
```