### PR TITLE
Update spark app id naming convention and limit length

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1098,7 +1098,7 @@ class SparkConfBuilder:
         if is_jupyter:
             raw_app_id = app_name
         else:
-            raw_app_id = f'{paasta_service}_{paasta_instance}_{int(time.time())}'
+            raw_app_id = f'{paasta_service}__{paasta_instance}__{int(time.time()) % 10000}'
         app_id = re.sub(r'[\.,-]', '_', _get_k8s_resource_name_limit_size_with_hash(raw_app_id))
 
         spark_conf.update({

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.18.4',
+    version='2.18.5',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -1143,7 +1143,19 @@ class TestGetSparkConf:
     def assert_app_id(self):
         def verify(output):
             key = 'spark.app.id'
-            assert output[key] == re.sub(r'[\.,-]', '_', output['spark.app.name'])
+            app_name = output['spark.app.name']
+            is_jupyter = 'jupyterhub' in app_name
+            paasta_service = output['spark.executorEnv.PAASTA_SERVICE']
+            paasta_instance = output['spark.executorEnv.PAASTA_INSTANCE']
+
+            if is_jupyter:
+                raw_app_id_prefix = app_name
+            else:
+                raw_app_id_prefix = f'{paasta_service}_{paasta_instance}_'
+            app_id_prefix = re.sub(r'[\.,-]', '_', raw_app_id_prefix)
+            output_app_id = output[key]
+            assert output_app_id.startswith(app_id_prefix)
+            assert len(output_app_id) <= 63
             return [key]
         return verify
 

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -1151,7 +1151,7 @@ class TestGetSparkConf:
             if is_jupyter:
                 raw_app_id_prefix = app_name
             else:
-                raw_app_id_prefix = f'{paasta_service}_{paasta_instance}_'
+                raw_app_id_prefix = f'{paasta_service}__{paasta_instance}__'
             app_id_prefix = re.sub(r'[\.,-]', '_', raw_app_id_prefix)
             output_app_id = output[key]
             assert output_app_id.startswith(app_id_prefix)


### PR DESCRIPTION
Follow up PR of #124
- Trim app id to match k8s pod label length limit
- For non-jupyterhub jobs: use `<paasta_service>_<paasta_instance>_<timestamp>` format