### PR TITLE
Support explicitly setting spark app id

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.18.5',
+    version='2.18.6',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',


### PR DESCRIPTION
Follow up PR of #125

* Support explicitly setting spark app id for handling edge cases (if any)
* Change app id postfix from last 4 digits of timestamp to a random string

Related: https://github.com/Yelp/paasta/pull/3682
