### PR TITLE
MLCOMPUTE-746 | Remove the option for explicitly specifying app id

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1030,7 +1030,6 @@ class SparkConfBuilder:
         aws_region: Optional[str] = None,
         service_account_name: Optional[str] = None,
         force_spark_resource_configs: bool = True,
-        spark_app_id: str = '',  # to be removed once verified all applications are not explicitly setting app id
     ) -> Dict[str, str]:
         """Build spark config dict to run with spark on paasta
 
@@ -1098,19 +1097,12 @@ class SparkConfBuilder:
         # in all places for metric systems:
         # - since in the Promehteus metrics endpoint those will be converted to '_'
         # - while the 'spark-app-selector' executor pod label will keep the original app id
-        if len(spark_app_id) == 0:
-            if is_jupyter:
-                raw_app_id = app_name
-            else:
-                random_postfix = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(4))
-                raw_app_id = f'{paasta_service}__{paasta_instance}__{random_postfix}'
-            app_id = re.sub(r'[\.,-]', '_', _get_k8s_resource_name_limit_size_with_hash(raw_app_id))
+        if is_jupyter:
+            raw_app_id = app_name
         else:
-            log.warning(
-                'We do not recommend users to set spark.app.id, as it could diminish the clarity of identification '
-                'and can potentially cause the monitoring dashboard to not work properly.',
-            )
-            app_id = spark_app_id
+            random_postfix = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(4))
+            raw_app_id = f'{paasta_service}__{paasta_instance}__{random_postfix}'
+        app_id = re.sub(r'[\.,-]', '_', _get_k8s_resource_name_limit_size_with_hash(raw_app_id))
 
         spark_conf.update({
             'spark.app.name': app_name,


### PR DESCRIPTION
We added the option for explicitly specifying Spark app id in #126 as a safety measure for rolling out the new app id naming convention.

Now the new naming convention has been fully rolled out without any problem and no one is currently using the option. So I'm going to remove the option to cleanup the logic and avoid problems caused by user explicitly set the id.

Related PR: https://github.com/Yelp/paasta/pull/3695