### PR TITLE
MLCOMPUTE-949 | Pick spark ui port from a preferred port range

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1068,6 +1068,9 @@ class SparkConfBuilder:
             spark_app_base_name
         )
 
+        # Pick a port from a pre-defined port range, which will then be used by our Jupyter
+        # server metric aggregator API. The aggregator API collects Prometheus metrics from multiple
+        # Spark sessions and exposes them through a single endpoint.
         ui_port = int(
             (spark_opts_from_env or {}).get('spark.ui.port') or
             utils.ephemeral_port_reserve_range(

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -77,8 +77,6 @@ K8S_BASE_VOLUMES: List[Dict[str, str]] = [
 
 SUPPORTED_CLUSTER_MANAGERS = ['kubernetes', 'local']
 DEFAULT_SPARK_RUN_CONFIG = '/nail/srv/configs/spark.yaml'
-PREFERRED_SPARK_UI_PORT_START = 39091
-PREFERRED_SPARK_UI_PORT_END = 39100
 
 log = logging.Logger(__name__)
 log.setLevel(logging.INFO)
@@ -1073,8 +1071,8 @@ class SparkConfBuilder:
         ui_port = int(
             (spark_opts_from_env or {}).get('spark.ui.port') or
             utils.ephemeral_port_reserve_range(
-                PREFERRED_SPARK_UI_PORT_START,
-                PREFERRED_SPARK_UI_PORT_END,
+                self.spark_constants.get('preferred_spark_ui_port_start'),
+                self.spark_constants.get('preferred_spark_ui_port_end'),
             ),
         )
 

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -20,13 +20,12 @@ from typing import Tuple
 from urllib.parse import urlparse
 
 import boto3
-import ephemeral_port_reserve
 import requests
 import yaml
 from boto3 import Session
 
+from service_configuration_lib import utils
 from service_configuration_lib.text_colors import TextColors
-from service_configuration_lib.utils import load_spark_srv_conf
 
 AWS_CREDENTIALS_DIR = '/etc/boto_cfg/'
 AWS_ENV_CREDENTIALS_PROVIDER = 'com.amazonaws.auth.EnvironmentVariableCredentialsProvider'
@@ -78,7 +77,8 @@ K8S_BASE_VOLUMES: List[Dict[str, str]] = [
 
 SUPPORTED_CLUSTER_MANAGERS = ['kubernetes', 'local']
 DEFAULT_SPARK_RUN_CONFIG = '/nail/srv/configs/spark.yaml'
-PREFERRED_SPARK_UI_PORT = 39091
+PREFERRED_SPARK_UI_PORT_START = 39091
+PREFERRED_SPARK_UI_PORT_END = 39100
 
 log = logging.Logger(__name__)
 log.setLevel(logging.INFO)
@@ -182,11 +182,6 @@ def assume_aws_role(
         DurationSeconds=session_duration,
     )
     return resp['Credentials']
-
-
-def _pick_random_port(preferred_port: int = 0) -> int:
-    """Return a random port. """
-    return ephemeral_port_reserve.reserve('0.0.0.0', preferred_port)
 
 
 def _get_k8s_docker_volumes_conf(
@@ -418,7 +413,7 @@ class SparkConfBuilder:
             (
                 self.spark_srv_conf, self.spark_constants, self.default_spark_srv_conf,
                 self.mandatory_default_spark_srv_conf, self.spark_costs,
-            ) = load_spark_srv_conf()
+            ) = utils.load_spark_srv_conf()
         except Exception as e:
             log.error(f'Failed to load Spark srv configs: {e}')
 
@@ -1077,7 +1072,10 @@ class SparkConfBuilder:
 
         ui_port = int(
             (spark_opts_from_env or {}).get('spark.ui.port') or
-            _pick_random_port(PREFERRED_SPARK_UI_PORT),
+            utils.ephemeral_port_reserve_range(
+                PREFERRED_SPARK_UI_PORT_START,
+                PREFERRED_SPARK_UI_PORT_END,
+            ),
         )
 
         spark_conf = {**(spark_opts_from_env or {}), **_filter_user_spark_opts(user_spark_opts)}

--- a/service_configuration_lib/utils.py
+++ b/service_configuration_lib/utils.py
@@ -37,28 +37,23 @@ def load_spark_srv_conf(preset_values=None) -> Tuple[Mapping, Mapping, Mapping, 
         raise e
 
 
-def ephemeral_port_reserve_range(preffered_port_start: int, preferred_port_end: int, ip='127.0.0.1') -> int:
+def ephemeral_port_reserve_range(preferred_port_start: int, preferred_port_end: int, ip='127.0.0.1') -> int:
     """
-    Bind to an ephemeral port, force it into the TIME_WAIT state, and unbind it.
+    Pick an available from the preferred port range. If all ports from the port range are unavailable,
+    pick a random available ephemeral port.
 
-    This means that further ephemeral port alloctions won't pick this "reserved" port,
-    but subprocesses can still bind to it explicitly, given that they use SO_REUSEADDR.
-    By default on linux you have a grace period of 60 seconds to reuse this port.
-    To check your own particular value:
-    $ cat /proc/sys/net/ipv4/tcp_fin_timeout
-    60
+    Implemetation referenced from upstream:
+    https://github.com/Yelp/ephemeral-port-reserve/blob/master/ephemeral_port_reserve.py
 
-    By default, the port will be reserved for localhost (aka 127.0.0.1).
-    To reserve a port for a different ip, provide the ip as the first argument.
-    Note that IP 0.0.0.0 is interpreted as localhost.
-
-    Referenced from: https://github.com/Yelp/ephemeral-port-reserve
+    This function is used to pick a Spark UI (API) port from a pre-defined port range which is used by
+    our Jupyter server metric aggregator. The aggregator API collects Prometheus metrics from multiple
+    Spark sessions and exposes them through a single endpoint.
     """
-    assert preffered_port_start <= preferred_port_end
+    assert preferred_port_start <= preferred_port_end
 
     with contextlib.closing(socket()) as s:
         binded = False
-        for port in range(preffered_port_start, preferred_port_end + 1):
+        for port in range(preferred_port_start, preferred_port_end + 1):
             s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
             try:
                 s.bind((ip, port))

--- a/service_configuration_lib/utils.py
+++ b/service_configuration_lib/utils.py
@@ -1,8 +1,15 @@
+import contextlib
+import errno
 import logging
+from socket import error as SocketError
+from socket import SO_REUSEADDR
+from socket import socket
+from socket import SOL_SOCKET
 from typing import Mapping
 from typing import Tuple
 
 import yaml
+
 
 DEFAULT_SPARK_RUN_CONFIG = '/nail/srv/configs/spark.yaml'
 
@@ -28,3 +35,52 @@ def load_spark_srv_conf(preset_values=None) -> Tuple[Mapping, Mapping, Mapping, 
     except Exception as e:
         log.warning(f'Failed to load {DEFAULT_SPARK_RUN_CONFIG}: {e}')
         raise e
+
+
+def ephemeral_port_reserve_range(preffered_port_start: int, preferred_port_end: int, ip='127.0.0.1') -> int:
+    """
+    Bind to an ephemeral port, force it into the TIME_WAIT state, and unbind it.
+
+    This means that further ephemeral port alloctions won't pick this "reserved" port,
+    but subprocesses can still bind to it explicitly, given that they use SO_REUSEADDR.
+    By default on linux you have a grace period of 60 seconds to reuse this port.
+    To check your own particular value:
+    $ cat /proc/sys/net/ipv4/tcp_fin_timeout
+    60
+
+    By default, the port will be reserved for localhost (aka 127.0.0.1).
+    To reserve a port for a different ip, provide the ip as the first argument.
+    Note that IP 0.0.0.0 is interpreted as localhost.
+
+    Referenced from: https://github.com/Yelp/ephemeral-port-reserve
+    """
+    assert preffered_port_start <= preferred_port_end
+
+    with contextlib.closing(socket()) as s:
+        binded = False
+        for port in range(preffered_port_start, preferred_port_end + 1):
+            s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+            try:
+                s.bind((ip, port))
+                binded = True
+                break
+            except SocketError as e:
+                # socket.error: EADDRINUSE Address already in use
+                if e.errno == errno.EADDRINUSE:
+                    continue
+                else:
+                    raise
+        if not binded:
+            s.bind((ip, 0))
+
+        # the connect below deadlocks on kernel >= 4.4.0 unless this arg is greater than zero
+        s.listen(1)
+
+        sockname = s.getsockname()
+
+        # these three are necessary just to get the port into a TIME_WAIT state
+        with contextlib.closing(socket()) as s2:
+            s2.connect(sockname)
+            sock, _ = s.accept()
+            with contextlib.closing(sock):
+                return sockname[1]

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.18.6',
+    version='2.18.7',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',


### PR DESCRIPTION
Pick the Spark UI (API) port from a preferred port range, for scraping metrics from multiple Spark sessions in a single Jupyter server.

Tested in a jupyter server and launched 11 Spark sessions, the port of the 11th session is a random ephemeral port that is currently available on the host/pod.

![image](https://github.com/Yelp/service_configuration_lib/assets/8851038/9168fe07-74c8-400a-9108-05967994ecb2)