### PR TITLE
Show warning message when spark app id is explicitly specified

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -39,6 +39,7 @@ CLUSTERMAN_YAML_FILE_PATH = '/nail/srv/configs/clusterman.yaml'
 
 NON_CONFIGURABLE_SPARK_OPTS = {
     'spark.master',
+    'spark.app.id',
     'spark.ui.port',
     'spark.mesos.principal',
     'spark.mesos.secret',
@@ -1051,7 +1052,6 @@ class SparkConfBuilder:
             If not provided, it uses cert files at {K8S_AUTH_FOLDER} to authenticate.
         :param force_spark_resource_configs: skip the resource/instances recalculation.
             This is strongly not recommended.
-        :param explcitly setting spark.app.id
         :returns: spark opts in a dict.
         """
         # Mesos deprecation

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.18.7',
+    version='2.18.8',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',


### PR DESCRIPTION
## Description
Add `spark.app.id` to `NON_CONFIGURABLE_SPARK_OPTS` for showing warning message when it is specified.

This change shouldn't affect any existing logic since the app id is set (overwritten) here at this line: https://github.com/Yelp/service_configuration_lib/blob/c9aaf8e267aba3dbc19982ed8dfc041d0bc1083a/service_configuration_lib/spark_config.py#L1108

## Test
<img width="862" alt="image" src="https://github.com/Yelp/service_configuration_lib/assets/8851038/1b138f55-2720-4e93-93ad-3981d684b88c">
