### PR TITLE
Limiting spark appname to 63 characters

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -1099,6 +1099,9 @@ class SparkConfBuilder:
             raw_app_id = f'{paasta_service}__{paasta_instance}__{random_postfix}'
         app_id = re.sub(r'[\.,-]', '_', _get_k8s_resource_name_limit_size_with_hash(raw_app_id))
 
+        # Starting Spark 3.4+, spark-app-name label has been added. Limiting to 63 characters
+        app_name = _get_k8s_resource_name_limit_size_with_hash(app_name)
+
         spark_conf.update({
             'spark.app.name': app_name,
             'spark.app.id': app_id,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.18.10',
+    version='2.18.11',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -1144,6 +1144,7 @@ class TestGetSparkConf:
         def verify(output):
             key = 'spark.app.name'
             assert output[key] == expected_output
+            assert len(output[key]) <= 63
             return [key]
         return verify
 


### PR DESCRIPTION
Address the limitation of 63 characters for spark-app-name label for Spark jobs as part of Spark 3.3+.

Test results as part of [MLCOMPUTE-1082](https://jira.yelpcorp.com/browse/MLCOMPUTE-1082)

I will push this on Monday only. 