### PR TITLE
Allow get_aws_credentials to assume_role_with_web_identity

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -114,6 +114,7 @@ def get_aws_credentials(
     assume_aws_role_arn: Optional[str] = None,
     session_duration: int = 3600,
     assume_role_user_creds_file: str = '/nail/etc/spark_role_assumer/spark_role_assumer.yaml',
+    use_default_session=False,
 ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
     """load aws creds using different method/file"""
     if no_aws_credentials:
@@ -132,6 +133,8 @@ def get_aws_credentials(
             log.warning(
                 'Tried to assume role with web identity but something went wrong ',
             )
+    elif use_default_session:
+        session = Session()
     elif service != DEFAULT_SPARK_SERVICE:
         service_credentials_path = os.path.join(AWS_CREDENTIALS_DIR, f'{service}.yaml')
         if os.path.exists(service_credentials_path):

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -137,8 +137,7 @@ def get_aws_credentials(
         token_path = os.environ.get('AWS_WEB_IDENTITY_TOKEN_FILE')
         role_arn = os.environ.get('AWS_ROLE_ARN')
         if not token_path or not role_arn:
-            log.warning('No web identity token file found.')
-            return None, None, None
+            raise Exception('Expected AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN to be set.')
         with open(token_path) as token_file:
             token = token_file.read()
         sts_client = boto3.client('sts')

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -186,10 +186,11 @@ def assume_aws_role(
             creds_dict = yaml.load(creds_file.read(), Loader=yaml.SafeLoader)
             access_key = creds_dict['AccessKeyId']
             secret_key = creds_dict['SecretAccessKey']
-    except PermissionError:
+    except (PermissionError, FileNotFoundError):
         log.warning(
-            'If using spark-run as a human, you must manually export '
-            'AWS session credentials first. See y/spark-run-aws-role',
+            f'Tried to use {key_file} but it is not available. --assume-aws-role '
+            'can only be used with ssh executor. If using spark-run as a human, '
+            'you must manually export AWS session credentials first. See y/spark-run-aws-role',
         )
         raise
     timestamp = int(time.time())


### PR DESCRIPTION
This change will allow the caller of get_aws_credentials to use assume_role_with_web_identity with a simple argument. This is ultimately to allow `paasta spark-run` to be used from within a Pod Identity context. The previous workaround was to create a AWS config file with a profile that did the same thing.

Pairs with https://github.com/Yelp/paasta/pull/3787 

Manual test, after setting ENV variables with a real token:
https://fluffy.yelpcorp.com/i/9nt6FK4T2dlSScKdVF53371flGRPS05F.html