### PR TITLE
Fix default user name label

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -270,6 +270,7 @@ def _get_k8s_spark_env(
     service_account_name: Optional[str] = None,
     include_self_managed_configs: bool = True,
     k8s_server_address: Optional[str] = None,
+    user: Optional[str] = None,
 ) -> Dict[str, str]:
     # RFC 1123: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
     # technically only paasta instance can be longer than 63 chars. But we apply the normalization regardless.
@@ -277,7 +278,8 @@ def _get_k8s_spark_env(
     _paasta_cluster = utils.get_k8s_resource_name_limit_size_with_hash(paasta_cluster)
     _paasta_service = utils.get_k8s_resource_name_limit_size_with_hash(paasta_service)
     _paasta_instance = utils.get_k8s_resource_name_limit_size_with_hash(paasta_instance)
-    user = os.environ.get('USER', '_unspecified_')
+    if not user:
+        user = os.environ.get('USER', 'UNSPECIFIED')
 
     spark_env = {
         'spark.master': f'k8s://https://k8s.{paasta_cluster}.paasta:6443',
@@ -1017,6 +1019,7 @@ class SparkConfBuilder:
         aws_region: Optional[str] = None,
         service_account_name: Optional[str] = None,
         force_spark_resource_configs: bool = True,
+        user: Optional[str] = None,
     ) -> Dict[str, str]:
         """Build spark config dict to run with spark on paasta
 
@@ -1129,6 +1132,7 @@ class SparkConfBuilder:
                 service_account_name=service_account_name,
                 include_self_managed_configs=not use_eks,
                 k8s_server_address=k8s_server_address,
+                user=user,
             ))
         elif cluster_manager == 'local':
             spark_conf.update(_get_local_spark_env(


### PR DESCRIPTION
For addressing the following pod creation error when the `USER` environment variable is not set.

```
metadata.labels: Invalid value: "_unspecified_": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```
