### PR TITLE
MLCOMPUTE-967 | Spark config calculation should result in failure if srv-configs can't be read

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -5,7 +5,6 @@ import logging
 import math
 import os
 import re
-import sys
 import time
 from typing import Any
 from typing import Dict
@@ -1075,7 +1074,11 @@ class SparkConfBuilder:
                     self.spark_constants.get('preferred_spark_ui_port_end'),
                 ),
             )
-        except Exception:
+        except Exception as e:
+            log.warning(
+                f'Could not get an available port using srv-config port range: {e}. '
+                'Using default port range to get an available port.',
+            )
             ui_port = utils.ephemeral_port_reserve_range()
 
         spark_conf = {**(spark_opts_from_env or {}), **_filter_user_spark_opts(user_spark_opts)}

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -2,11 +2,10 @@ import functools
 import itertools
 import json
 import logging
-import sys
-
 import math
 import os
 import re
+import sys
 import time
 from typing import Any
 from typing import Dict
@@ -1076,7 +1075,7 @@ class SparkConfBuilder:
                     self.spark_constants.get('preferred_spark_ui_port_end'),
                 ),
             )
-        except Exception as e:
+        except Exception:
             ui_port = utils.ephemeral_port_reserve_range()
 
         spark_conf = {**(spark_opts_from_env or {}), **_filter_user_spark_opts(user_spark_opts)}

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -396,7 +396,7 @@ class SparkConfBuilder:
         except Exception as e:
             log.error(f'Failed to load Spark srv configs: {e}')
             # should fail because Spark config calculation depends on values in srv-configs
-            sys.exit(1)
+            raise e
 
     def _append_spark_prometheus_conf(self, spark_opts: Dict[str, str]) -> Dict[str, str]:
         spark_opts['spark.ui.prometheus.enabled'] = 'true'

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -2,6 +2,8 @@ import functools
 import itertools
 import json
 import logging
+import sys
+
 import math
 import os
 import re
@@ -104,7 +106,6 @@ def _load_aws_credentials_from_yaml(yaml_file_path) -> Tuple[str, str, Optional[
 
 def get_aws_credentials(
     service: Optional[str] = DEFAULT_SPARK_SERVICE,
-    no_aws_credentials: bool = False,
     aws_credentials_yaml: Optional[str] = None,
     profile_name: Optional[str] = None,
     session: Optional[boto3.Session] = None,
@@ -114,9 +115,7 @@ def get_aws_credentials(
     assume_role_user_creds_file: str = '/nail/etc/spark_role_assumer/spark_role_assumer.yaml',
 ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
     """load aws creds using different method/file"""
-    if no_aws_credentials:
-        return None, None, None
-    elif aws_credentials_yaml:
+    if aws_credentials_yaml:
         return _load_aws_credentials_from_yaml(aws_credentials_yaml)
     elif aws_credentials_json:
         with open(aws_credentials_json, 'r') as f:
@@ -397,6 +396,8 @@ class SparkConfBuilder:
             ) = utils.load_spark_srv_conf()
         except Exception as e:
             log.error(f'Failed to load Spark srv configs: {e}')
+            # should fail because Spark config calculation depends on values in srv-configs
+            sys.exit(1)
 
     def _append_spark_prometheus_conf(self, spark_opts: Dict[str, str]) -> Dict[str, str]:
         spark_opts['spark.ui.prometheus.enabled'] = 'true'
@@ -1067,13 +1068,16 @@ class SparkConfBuilder:
         # Pick a port from a pre-defined port range, which will then be used by our Jupyter
         # server metric aggregator API. The aggregator API collects Prometheus metrics from multiple
         # Spark sessions and exposes them through a single endpoint.
-        ui_port = int(
-            (spark_opts_from_env or {}).get('spark.ui.port') or
-            utils.ephemeral_port_reserve_range(
-                self.spark_constants.get('preferred_spark_ui_port_start'),
-                self.spark_constants.get('preferred_spark_ui_port_end'),
-            ),
-        )
+        try:
+            ui_port = int(
+                (spark_opts_from_env or {}).get('spark.ui.port') or
+                utils.ephemeral_port_reserve_range(
+                    self.spark_constants.get('preferred_spark_ui_port_start'),
+                    self.spark_constants.get('preferred_spark_ui_port_end'),
+                ),
+            )
+        except Exception as e:
+            ui_port = utils.ephemeral_port_reserve_range()
 
         spark_conf = {**(spark_opts_from_env or {}), **_filter_user_spark_opts(user_spark_opts)}
         random_postfix = utils.get_random_string(4)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.18.14',
+    version='2.18.15',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -57,9 +57,6 @@ class TestGetAWSCredentials:
     creds = {'aws_access_key_id': access_key, 'aws_secret_access_key': secret_key}
     expected_creds = (access_key, secret_key, None)
 
-    def test_no_aws_creds(self):
-        assert spark_config.get_aws_credentials(no_aws_credentials=True) == (None, None, None)
-
     @pytest.mark.parametrize('aws_creds', [temp_creds, creds])
     def test_aws_credentials_yaml(self, tmpdir, aws_creds):
         fp = tmpdir.join('test.yaml')


### PR DESCRIPTION
- Spark config generation is leading to failures like KeyError in runtime in cases where srv-configs are not present. We should actively fail fast in such cases rather than wait for KeyError failures in runtime
- Remove obsolete `no_aws_credentials` arg from `get_aws_credentials` function