### PR TITLE
Update spark-run to no longer override --aws-profile

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -148,6 +148,8 @@ def get_aws_credentials(
             session['Credentials']['SecretAccessKey'],
             session['Credentials']['SessionToken'],
         )
+    elif profile_name:
+        return use_aws_profile(profile_name=profile_name, session=session)
     elif service != DEFAULT_SPARK_SERVICE:
         service_credentials_path = os.path.join(AWS_CREDENTIALS_DIR, f'{service}.yaml')
         if os.path.exists(service_credentials_path):
@@ -158,6 +160,13 @@ def get_aws_credentials(
                 'Falling back to user credentials.',
             )
 
+    return use_aws_profile(session=session)
+
+
+def use_aws_profile(
+    profile_name: str = 'default',
+    session: Optional[boto3.Session] = None,
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
     session = session or Session(profile_name=profile_name)
     creds = session.get_credentials()
     return (

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -100,8 +100,20 @@ class TestGetAWSCredentials:
         fp.write(json.dumps({'accessKeyId': self.access_key, 'secretAccessKey': self.secret_key}))
         assert spark_config.get_aws_credentials(aws_credentials_json=str(fp)) == self.expected_creds
 
+    def test_use_profile_and_service(self, mock_session):
+        profile = 'test_profile'
+        service = 'test_service'
+        assert spark_config.get_aws_credentials(profile_name=profile, service=service) == self.expected_temp_creds
+
     def test_use_profile(self, mock_session):
         assert spark_config.get_aws_credentials(profile_name='test_profile') == self.expected_temp_creds
+
+    def test_use_default_profile(self, mock_session):
+        assert spark_config.get_aws_credentials(service=spark_config.DEFAULT_SPARK_SERVICE) == self.expected_temp_creds
+
+    def test_no_service_specified(self, mock_session):
+        # should default to using the `default` user profile if no other credentials specified
+        assert spark_config.get_aws_credentials() == self.expected_temp_creds
 
     @pytest.fixture
     def mock_client(self):


### PR DESCRIPTION
Current behaviour from `paasta spark-run` is that `--aws-profile` will be overwritten if `--service` is provided (e.g. aws credentials will be obtained from `/etc/boto_cfg/<service>.yaml` instead of from the specified AWS profile)

This has caused some confusion from users, therefore this PR updates the behaviour such that:
- if `--aws-profile` is provided, use that value
- in absence of `--aws-profile`, then try to get credentials from boto_cfg
- in absence of any credential information provided, use the `default` AWS user profile