### PR TITLE
MLCOMPUTE-1497 | add methods to get total driver memory including overhead

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -414,6 +414,10 @@ def _filter_user_spark_opts(user_spark_opts: Mapping[str, str]) -> MutableMappin
     }
 
 
+def get_total_driver_memory_mb(spark_conf: Dict[str, str]) -> int:
+    return int(utils.get_spark_driver_memory_mb(spark_conf) + utils.get_spark_driver_memory_overhead_mb(spark_conf))
+
+
 class SparkConfBuilder:
 
     def __init__(self):

--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -148,8 +148,13 @@ def get_aws_credentials(
             session['Credentials']['SecretAccessKey'],
             session['Credentials']['SessionToken'],
         )
+    # use the boto3 session if provided
+    elif session:
+        return use_aws_profile(session=session)
+    # use the aws profile if provided
     elif profile_name:
-        return use_aws_profile(profile_name=profile_name, session=session)
+        return use_aws_profile(profile_name=profile_name)
+    # use the service specific boto creds if boto3 session or aws profile is not provided
     elif service != DEFAULT_SPARK_SERVICE:
         service_credentials_path = os.path.join(AWS_CREDENTIALS_DIR, f'{service}.yaml')
         if os.path.exists(service_credentials_path):
@@ -159,8 +164,8 @@ def get_aws_credentials(
                 f'Did not find service AWS credentials at {service_credentials_path}. '
                 'Falling back to user credentials.',
             )
-
-    return use_aws_profile(session=session)
+    # try to get default aws profile creds if nothing else is provided
+    return use_aws_profile()
 
 
 def use_aws_profile(

--- a/service_configuration_lib/utils.py
+++ b/service_configuration_lib/utils.py
@@ -11,12 +11,12 @@ from socket import error as SocketError
 from socket import SO_REUSEADDR
 from socket import socket
 from socket import SOL_SOCKET
+from typing import Dict
 from typing import Mapping
 from typing import Tuple
-from typing import Literal
-from typing import Dict
 
 import yaml
+from typing_extensions import Literal
 
 DEFAULT_SPARK_RUN_CONFIG = '/nail/srv/configs/spark.yaml'
 POD_TEMPLATE_PATH = '/nail/tmp/spark-pt-{file_uuid}.yaml'
@@ -26,7 +26,7 @@ LOCALHOST = '127.0.0.1'
 EPHEMERAL_PORT_START = 49152
 EPHEMERAL_PORT_END = 65535
 
-MEM_MULTIPLIER = {"k": 1024, "m": 1024**2, "g": 1024**3, "t": 1024**4}
+MEM_MULTIPLIER = {'k': 1024, 'm': 1024**2, 'g': 1024**3, 't': 1024**4}
 
 SPARK_DRIVER_MEM_DEFAULT_MB = 2048
 SPARK_DRIVER_MEM_OVERHEAD_FACTOR_DEFAULT = 0.1
@@ -157,7 +157,7 @@ def get_runtime_env() -> str:
         return 'unknown'
 
 
-def get_spark_memory_in_unit(mem: str, unit: Literal["k", "m", "g", "t"]) -> float:
+def get_spark_memory_in_unit(mem: str, unit: Literal['k', 'm', 'g', 't']) -> float:
     """
     Converts Spark memory to the desired unit.
     mem is the same format as JVM memory strings: just number or number followed by 'k', 'm', 'g' or 't'.
@@ -170,10 +170,10 @@ def get_spark_memory_in_unit(mem: str, unit: Literal["k", "m", "g", "t"]) -> flo
         try:
             memory_bytes = float(mem[:-1]) * MEM_MULTIPLIER[mem[-1]]
         except (ValueError, IndexError):
-            print(f"Unable to parse memory value {mem}.")
+            print(f'Unable to parse memory value {mem}.')
             raise
     memory_unit = memory_bytes / MEM_MULTIPLIER[unit]
-    return memory_unit
+    return round(memory_unit, 5)
 
 
 def get_spark_driver_memory_mb(spark_conf: Dict[str, str]) -> float:
@@ -181,9 +181,9 @@ def get_spark_driver_memory_mb(spark_conf: Dict[str, str]) -> float:
     Returns the Spark driver memory in MB.
     """
     # spark_conf is expected to have "spark.driver.memory" since it is a mandatory default from srv-configs.
-    driver_mem = spark_conf["spark.driver.memory"]
+    driver_mem = spark_conf['spark.driver.memory']
     try:
-        return get_spark_memory_in_unit(str(driver_mem), "m")
+        return get_spark_memory_in_unit(str(driver_mem), 'm')
     except (ValueError, IndexError):
         return SPARK_DRIVER_MEM_DEFAULT_MB
 
@@ -194,15 +194,17 @@ def get_spark_driver_memory_overhead_mb(spark_conf: Dict[str, str]) -> float:
     """
     # Use spark.driver.memoryOverhead if it is set.
     try:
-        driver_mem_overhead = spark_conf["spark.driver.memoryOverhead"]
+        driver_mem_overhead = spark_conf['spark.driver.memoryOverhead']
         try:
             # spark.driver.memoryOverhead default unit is MB
             driver_mem_overhead_mb = float(driver_mem_overhead)
         except ValueError:
-            driver_mem_overhead_mb = get_spark_memory_in_unit(str(driver_mem_overhead), "m")
+            driver_mem_overhead_mb = get_spark_memory_in_unit(str(driver_mem_overhead), 'm')
     # Calculate spark.driver.memoryOverhead based on spark.driver.memory and spark.driver.memoryOverheadFactor.
     except Exception:
         driver_mem_mb = get_spark_driver_memory_mb(spark_conf)
-        driver_mem_overhead_factor = float(spark_conf.get("spark.driver.memoryOverheadFactor", SPARK_DRIVER_MEM_OVERHEAD_FACTOR_DEFAULT))
+        driver_mem_overhead_factor = float(
+            spark_conf.get('spark.driver.memoryOverheadFactor', SPARK_DRIVER_MEM_OVERHEAD_FACTOR_DEFAULT),
+        )
         driver_mem_overhead_mb = driver_mem_mb * driver_mem_overhead_factor
-    return driver_mem_overhead_mb
+    return round(driver_mem_overhead_mb, 5)

--- a/service_configuration_lib/utils.py
+++ b/service_configuration_lib/utils.py
@@ -13,6 +13,8 @@ from socket import socket
 from socket import SOL_SOCKET
 from typing import Mapping
 from typing import Tuple
+from typing import Literal
+from typing import Dict
 
 import yaml
 
@@ -23,6 +25,11 @@ SPARK_EXECUTOR_POD_TEMPLATE = '/nail/srv/configs/spark_executor_pod_template.yam
 LOCALHOST = '127.0.0.1'
 EPHEMERAL_PORT_START = 49152
 EPHEMERAL_PORT_END = 65535
+
+MEM_MULTIPLIER = {"k": 1024, "m": 1024**2, "g": 1024**3, "t": 1024**4}
+
+SPARK_DRIVER_MEM_DEFAULT_MB = 2048
+SPARK_DRIVER_MEM_OVERHEAD_FACTOR_DEFAULT = 0.1
 
 
 log = logging.Logger(__name__)
@@ -148,3 +155,54 @@ def get_runtime_env() -> str:
         # we could also just crash or return None, but this seems a little easier to find
         # should we somehow run into this at Yelp
         return 'unknown'
+
+
+def get_spark_memory_in_unit(mem: str, unit: Literal["k", "m", "g", "t"]) -> float:
+    """
+    Converts Spark memory to the desired unit.
+    mem is the same format as JVM memory strings: just number or number followed by 'k', 'm', 'g' or 't'.
+    unit can be 'k', 'm', 'g' or 't'.
+    Returns memory as a float converted to the desired unit.
+    """
+    try:
+        memory_bytes = float(mem)
+    except ValueError:
+        try:
+            memory_bytes = float(mem[:-1]) * MEM_MULTIPLIER[mem[-1]]
+        except (ValueError, IndexError):
+            print(f"Unable to parse memory value {mem}.")
+            raise
+    memory_unit = memory_bytes / MEM_MULTIPLIER[unit]
+    return memory_unit
+
+
+def get_spark_driver_memory_mb(spark_conf: Dict[str, str]) -> float:
+    """
+    Returns the Spark driver memory in MB.
+    """
+    # spark_conf is expected to have "spark.driver.memory" since it is a mandatory default from srv-configs.
+    driver_mem = spark_conf["spark.driver.memory"]
+    try:
+        return get_spark_memory_in_unit(str(driver_mem), "m")
+    except (ValueError, IndexError):
+        return SPARK_DRIVER_MEM_DEFAULT_MB
+
+
+def get_spark_driver_memory_overhead_mb(spark_conf: Dict[str, str]) -> float:
+    """
+    Returns the Spark driver memory overhead in bytes.
+    """
+    # Use spark.driver.memoryOverhead if it is set.
+    try:
+        driver_mem_overhead = spark_conf["spark.driver.memoryOverhead"]
+        try:
+            # spark.driver.memoryOverhead default unit is MB
+            driver_mem_overhead_mb = float(driver_mem_overhead)
+        except ValueError:
+            driver_mem_overhead_mb = get_spark_memory_in_unit(str(driver_mem_overhead), "m")
+    # Calculate spark.driver.memoryOverhead based on spark.driver.memory and spark.driver.memoryOverheadFactor.
+    except Exception:
+        driver_mem_mb = get_spark_driver_memory_mb(spark_conf)
+        driver_mem_overhead_factor = float(spark_conf.get("spark.driver.memoryOverheadFactor", SPARK_DRIVER_MEM_OVERHEAD_FACTOR_DEFAULT))
+        driver_mem_overhead_mb = driver_mem_mb * driver_mem_overhead_factor
+    return driver_mem_overhead_mb

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.18.18',
+    version='2.18.19',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='service-configuration-lib',
-    version='2.18.19',
+    version='2.18.20',
     provides=['service_configuration_lib'],
     description='Start, stop, and inspect Yelp SOA services',
     url='https://github.com/Yelp/service_configuration_lib',

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -12,6 +12,9 @@ from service_configuration_lib import utils
 from service_configuration_lib.utils import ephemeral_port_reserve_range
 from service_configuration_lib.utils import LOCALHOST
 
+from typing import cast
+from typing import Literal
+
 
 MOCK_ENV_NAME = 'mock_env_name'
 
@@ -72,6 +75,73 @@ def test_get_k8s_resource_name_limit_size_with_hash(instance_name, expected_inst
 def test_generate_pod_template_path(hex_value):
     with mock.patch.object(uuid, 'uuid4', return_value=uuid.UUID(hex=hex_value)):
         assert utils.generate_pod_template_path() == f'/nail/tmp/spark-pt-{hex_value}.yaml'
+
+
+@pytest.mark.parametrize(
+    'mem_str,unit_str,expected_mem',
+    (
+        ('13425m', "m", 13425),  # Simple case
+        ('138412032', "m", 132),  # Bytes to MB
+        ('65536k', 'g', 0.0625),  # KB to GB
+        ('1t', 'g', 1024),  # TB to GB
+        ('1.5g', 'm', 1536),  # GB to MB with decimal
+        ('2048k', 'm', 2),  # KB to MB
+        ('0.5g', 'k', 524288),  # GB to KB
+        ('1024m', 't', 0.001),  # MB to TB
+        ('1.5t', 'm', 1572864),  # TB to MB with decimal
+    ),
+)
+def test_get_spark_memory_in_unit(mem_str, unit_str, expected_mem):
+    assert expected_mem == utils.get_spark_memory_in_unit(mem_str, cast(Literal["k", "m", "g", "t"], unit_str))
+
+
+def test_get_spark_memory_in_unit_exceptions():
+    with pytest.raises(ValueError):
+        utils.get_spark_memory_in_unit("1x", "k")
+    with pytest.raises(IndexError):
+        utils.get_spark_memory_in_unit("1024mb", "m")
+
+@pytest.mark.parametrize(
+    'spark_conf,expected_mem',
+    [
+        ({"spark.driver.memory": "13425m"}, 13425),  # Simple case
+        ({"spark.driver.memory": "138412032"}, 132),  # Bytes to MB
+        ({"spark.driver.memory": "65536k"}, 64),  # KB to MB
+        ({"spark.driver.memory": "1g"}, 1024),  # GB to MB
+        ({"spark.driver.memory": "invalid"}, utils.SPARK_DRIVER_MEM_DEFAULT_MB),  # Invalid case
+        ({"spark.driver.memory": "1.5g"}, 1536),  # GB to MB with decimal
+        ({"spark.driver.memory": "2048k"}, 2),  # KB to MB
+        ({"spark.driver.memory": "0.5t"}, 524288),  # TB to MB
+        ({"spark.driver.memory": "1024m"}, 1024),  # MB to MB
+        ({"spark.driver.memory": "1.5t"}, 1572864),  # TB to MB with decimal
+    ]
+)
+def test_get_spark_driver_memory_mb(spark_conf, expected_mem):
+    assert expected_mem == utils.get_spark_driver_memory_mb(spark_conf)
+
+
+@pytest.mark.parametrize(
+    'spark_conf,expected_mem_overhead',
+    [
+        ({"spark.driver.memoryOverhead": "1024"}, 1024),  # Simple case
+        ({"spark.driver.memoryOverhead": "1g"}, 1024 * 1024),  # GB to MB
+        ({"spark.driver.memory": "10240m", "spark.driver.memoryOverheadFactor": "0.2"}, 2048),  # Custom overhead factor
+        ({"spark.driver.memory": "10240m"}, 1024),  # Using default overhead factor
+        ({"spark.driver.memory": "invalid"}, utils.SPARK_DRIVER_MEM_DEFAULT_MB * utils.SPARK_DRIVER_MEM_OVERHEAD_FACTOR_DEFAULT),
+        # Invalid case
+        ({"spark.driver.memoryOverhead": "1.5g"}, 1536 * 1024),  # GB to MB with decimal
+        ({"spark.driver.memory": "2048k", "spark.driver.memoryOverheadFactor": "0.05"}, 0.1),
+        # KB to MB with custom factor
+        ({"spark.driver.memory": "0.5t", "spark.driver.memoryOverheadFactor": "0.15"}, 78643.2),
+        # TB to MB with custom factor
+        ({"spark.driver.memory": "1024m", "spark.driver.memoryOverheadFactor": "0.25"}, 256),
+        # MB to MB with custom factor
+        ({"spark.driver.memory": "1.5t", "spark.driver.memoryOverheadFactor": "0.05"}, 78643.2),
+        # TB to MB with custom factor
+    ]
+)
+def test_get_spark_driver_memory_overhead_mb(spark_conf, expected_mem_overhead):
+    assert expected_mem_overhead == utils.get_spark_driver_memory_overhead_mb(spark_conf)
 
 
 @pytest.fixture


### PR DESCRIPTION
- Add methods to get total driver memory needed by paasta to assign correct Spark driver pod resources