### PR TITLE
Add PEP-561 type-support marker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ setup(
     author='Yelp Compute Infrastructure Team',
     author_email='opensource+scl@yelp.com',
     packages=find_packages(exclude=['tests', 'scripts']),
+    package_data={
+        'service_configuration_lib': ['py.typed'],
+    },
     install_requires=[
         'ephemeral-port-reserve >= 1.1.0',
         'PyYAML >= 5.1',


### PR DESCRIPTION
This will tell mypy and other tooling that this package is typed and that the types in this library (when present) should be used.

Once we start using a version with this in paasta, we'll unearth two failing type-checks:
```
paasta_tools/tron_tools.py:354: error: Argument "extra_volumes" to "get_spark_conf" of "SparkConfBuilder" has incompatible type "List[DockerVolume]"; expected "Optional[List[Mapping[str, str]]]"
paasta_tools/cli/cmds/spark_run.py:1236: error: Argument "extra_volumes" to "get_spark_conf" of "SparkConfBuilder" has incompatible type "List[DockerVolume]"; expected "Optional[List[Mapping[str, str]]]"
```
but:
a) these are easy to fix and,
b) it's a good thing that we're now using the right types :p