### PR TITLE
MLCOMPUTE-2733 | Add paasta service and instance name to pod annotations

### DIFF
--- a/service_configuration_lib/spark_config.py
+++ b/service_configuration_lib/spark_config.py
@@ -330,6 +330,8 @@ def _get_k8s_spark_env(
         'spark.kubernetes.executor.label.paasta.yelp.com/service': _paasta_service,
         'spark.kubernetes.executor.label.paasta.yelp.com/instance': _paasta_instance,
         'spark.kubernetes.executor.label.paasta.yelp.com/cluster': _paasta_cluster,
+        'spark.kubernetes.executor.annotation.paasta.yelp.com/service': paasta_service,
+        'spark.kubernetes.executor.annotation.paasta.yelp.com/instance': paasta_instance,
         'spark.kubernetes.executor.label.spark.yelp.com/user': user,
         'spark.kubernetes.executor.label.spark.yelp.com/driver_ui_port': str(driver_ui_port),
         'spark.kubernetes.node.selector.yelp.com/pool': paasta_pool,

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -1235,6 +1235,8 @@ class TestGetSparkConf:
             'spark.kubernetes.executor.label.paasta.yelp.com/service': self.service,
             'spark.kubernetes.executor.label.paasta.yelp.com/instance': self.instance,
             'spark.kubernetes.executor.label.paasta.yelp.com/cluster': self.cluster,
+            'spark.kubernetes.executor.annotation.paasta.yelp.com/service': self.service,
+            'spark.kubernetes.executor.annotation.paasta.yelp.com/instance': self.instance,
             'spark.kubernetes.executor.label.spark.yelp.com/user': TEST_USER,
             'spark.kubernetes.executor.label.spark.yelp.com/driver_ui_port': str(expected_ui_port),
             'spark.kubernetes.node.selector.yelp.com/pool': self.pool,


### PR DESCRIPTION
Add pod annotations `paasta.yelp.com/service` and `paasta.yelp.com/instance` to Spark executor pods.

Tested by installing a build to a local paasta repo and run a test Spark session.