### PR TITLE
MLCOMPUTE-4648 | Revise DRA default settings

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 # on python 3.6.0 (xenial) (https://github.com/nedbat/coveragepy/issues/703)
 coverage<5
 jaraco.functools==4.1.0
+jaraco.text==3.12.0
 mock
 more-itertools
 mypy==1.14.1

--- a/tests/spark_config_test.py
+++ b/tests/spark_config_test.py
@@ -683,7 +683,6 @@ class TestGetSparkConf:
                     'spark.dynamicAllocation.shuffleTracking.enabled': 'true',
                     'spark.dynamicAllocation.executorAllocationRatio': '0.8',
                     'spark.dynamicAllocation.cachedExecutorIdleTimeout': '1500s',
-                    'spark.dynamicAllocation.minExecutors': '0',
                     'spark.dynamicAllocation.maxExecutors': '2',
                     'spark.executor.instances': '0',
                 },
@@ -714,11 +713,10 @@ class TestGetSparkConf:
                 {
                     'spark.dynamicAllocation.enabled': 'true',
                     'spark.dynamicAllocation.maxExecutors': '821',
-                    'spark.dynamicAllocation.minExecutors': '205',
                     'spark.dynamicAllocation.shuffleTracking.enabled': 'true',
                     'spark.dynamicAllocation.executorAllocationRatio': '0.8',
                     'spark.dynamicAllocation.cachedExecutorIdleTimeout': '1500s',
-                    'spark.executor.instances': '205',
+                    'spark.executor.instances': '0',
                 },
             ),
             # dynamic resource allocation enabled with Jupyterhub
@@ -731,7 +729,6 @@ class TestGetSparkConf:
                 {
                     'spark.dynamicAllocation.enabled': 'true',
                     'spark.dynamicAllocation.maxExecutors': '821',
-                    'spark.dynamicAllocation.minExecutors': '0',
                     'spark.dynamicAllocation.shuffleTracking.enabled': 'true',
                     'spark.dynamicAllocation.executorAllocationRatio': '0.8',
                     'spark.dynamicAllocation.cachedExecutorIdleTimeout': '2400s',
@@ -755,7 +752,7 @@ class TestGetSparkConf:
                     'spark.executor.instances': '606',
                 },
                 {
-                    'spark.executor.instances': '151',  # enabled by default, 606/4
+                    'spark.executor.instances': '0',  # DRA enabled by default, initialExecutors = minExecutors = 0
                 },
             ),
         ],


### PR DESCRIPTION
## Changes
* Keep minExecutors as Spark default 0, instead of using `spark.yelp.dra.minExecutorRatio` to calculate
    * This avoids additional costs from idle executors, especially for gpu training
* Set `spark.executor.instances` as `initialExecutors` instead of `minExecutors`
    * The default value of initialExecutors is minExecutors

## Test
Tested with paasta spark-run and spark-tools in jupyter by installed the whl.